### PR TITLE
Updates to river-status protocol

### DIFF
--- a/protocol/river-status-unstable-v1.xml
+++ b/protocol/river-status-unstable-v1.xml
@@ -78,6 +78,13 @@
       </description>
       <arg name="tags" type="array" summary="array of 32-bit bitfields"/>
     </event>
+
+    <event name="layout">
+      <description summary="layout status of an output">
+        Sent when the layout of an output has changed.
+      </description>
+      <arg name="layout_name" type="string" summary="name of the layout"/>
+    </event>
   </interface>
 
   <interface name="zriver_seat_status_v1" version="2">

--- a/protocol/river-status-unstable-v1.xml
+++ b/protocol/river-status-unstable-v1.xml
@@ -80,7 +80,7 @@
     </event>
   </interface>
 
-  <interface name="zriver_seat_status_v1" version="1">
+  <interface name="zriver_seat_status_v1" version="2">
     <description summary="track seat focus">
       This interface allows clients to receive information about the current
       focus of a seat. Note that (un)focused_output events will only be sent
@@ -115,6 +115,9 @@
         if no view is focused or the focused view did not set a title.
       </description>
       <arg name="title" type="string" summary="title of the focused view"/>
+      <arg name="app_id" type="string" summary="app-id of the focused view"/>
+      <arg name="shell" type="string" summary="shell of the focused view"/>
+      <arg name="tags" type="uint" summary="32-bit bitfield"/>
     </event>
   </interface>
 </protocol>

--- a/protocol/river-status-unstable-v1.xml
+++ b/protocol/river-status-unstable-v1.xml
@@ -47,10 +47,13 @@
     </request>
   </interface>
 
-  <interface name="zriver_output_status_v1" version="1">
+  <interface name="zriver_output_status_v1" version="2">
     <description summary="track output tags and focus">
       This interface allows clients to receive information about the current
       windowing state of an output.
+
+      After all river_output_status properties have been sent, wl_output.done
+      is sent to allow atomic changes.
     </description>
 
     <request name="destroy" type="destructor">


### PR DESCRIPTION
1. Send `wl_output.done` after all `river_output_status` properties have been sent to allow atomic changes. (Allows clients like status bars to only render on `wl_output.done`, which reduces complexity and is more efficient).

2. Send more information in `river_seat_status.focused_view`, which may be useful to clients.

3. Send event when layout changed. This allows clients like status bars to display the name of the layout.