### PR TITLE
cursor: Support resizing in all four directions

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -214,6 +214,13 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 		- move-view
 		- resize-view
 
+	When _mode_ is resize-view, if the pointer is near a corner, the view
+	can be resized alongside both x and y axis, and if the pointer is near
+	an edge, the axis parallel to the edge is locked. The view is anchored
+	at the corner or edge opposite to the pointer. The pointer being in the
+	center of the view will be treated as if the pointer was in the lower
+	right corner.
+
 *unmap* [_-release_] _mode_ _modifiers_ _key_
 	Remove the mapping defined by the arguments:
 

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -41,7 +41,7 @@ pub const WarpCursorMode = enum {
 background_color: [4]f32 = [_]f32{ 0.0, 0.16862745, 0.21176471, 1.0 }, // Solarized base03
 
 /// Width of borders in pixels
-border_width: u32 = 2,
+border_width: u16 = 2,
 
 /// Color of border of focused window in RGBA
 border_color_focused: [4]f32 = [_]f32{ 0.57647059, 0.63137255, 0.63137255, 1.0 }, // Solarized base1

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -145,10 +145,10 @@ pub fn getAppId(self: Self) ?[*:0]const u8 {
 pub fn getConstraints(self: Self) View.Constraints {
     const state = &self.xdg_surface.role_data.toplevel.current;
     return .{
-        .min_width = std.math.max(state.min_width, View.min_size),
-        .max_width = if (state.max_width > 0) state.max_width else std.math.maxInt(u32),
-        .min_height = std.math.max(state.min_height, View.min_size),
-        .max_height = if (state.max_height > 0) state.max_height else std.math.maxInt(u32),
+        .min_width = util.safeIntDownCast(u31, state.min_width),
+        .min_height = util.safeIntDownCast(u31, state.min_height),
+        .max_width = if (state.max_width > 0) util.safeIntDownCast(u31, state.max_width) else std.math.maxInt(u31),
+        .max_height = if (state.max_height > 0) util.safeIntDownCast(u31, state.max_height) else std.math.maxInt(u31),
     };
 }
 

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -23,6 +23,7 @@ const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;
 
 const server = &@import("main.zig").server;
+const util = @import("util.zig");
 
 const Box = @import("Box.zig");
 const View = @import("View.zig");
@@ -123,22 +124,22 @@ pub fn getConstraints(self: Self) View.Constraints {
     const hints = self.xwayland_surface.size_hints orelse return .{
         .min_width = View.min_size,
         .min_height = View.min_size,
-        .max_width = math.maxInt(u32),
-        .max_height = math.maxInt(u32),
+        .max_width = math.maxInt(u31),
+        .max_height = math.maxInt(u31),
     };
     return .{
-        .min_width = @intCast(u32, math.max(hints.min_width, View.min_size)),
-        .min_height = @intCast(u32, math.max(hints.min_height, View.min_size)),
+        .min_width = util.safeIntDownCast(u31, math.max(hints.min_width, View.min_size)),
+        .min_height = util.safeIntDownCast(u31, math.max(hints.min_height, View.min_size)),
 
         .max_width = if (hints.max_width > 0)
-            math.max(@intCast(u32, hints.max_width), View.min_size)
+            util.safeIntDownCast(u31, math.max(hints.max_width, View.min_size))
         else
-            math.maxInt(u32),
+            math.maxInt(u31),
 
         .max_height = if (hints.max_height > 0)
-            math.max(@intCast(u32, hints.max_height), View.min_size)
+            util.safeIntDownCast(u31, math.max(hints.max_height, View.min_size))
         else
-            math.maxInt(u32),
+            math.maxInt(u31),
     };
 }
 

--- a/river/command/config.zig
+++ b/river/command/config.zig
@@ -33,7 +33,7 @@ pub fn borderWidth(
     if (args.len < 2) return Error.NotEnoughArguments;
     if (args.len > 2) return Error.TooManyArguments;
 
-    server.config.border_width = try fmt.parseInt(u32, args[1], 10);
+    server.config.border_width = try fmt.parseInt(u16, args[1], 10);
     server.root.arrangeAll();
     server.root.startTransaction();
 }

--- a/river/util.zig
+++ b/river/util.zig
@@ -17,6 +17,21 @@
 
 const std = @import("std");
 const os = std.os;
+const math = std.math;
 
 /// The global general-purpose allocator used throughout river's code
 pub const gpa = std.heap.c_allocator;
+
+/// like @intCast(), but only for casting to a type with fewer bits and casting
+/// a value too large for the target type is not undefined.
+pub fn safeIntDownCast(comptime T: type, val: anytype) T {
+    comptime {
+        const out_info = @typeInfo(T);
+        const in_info = @typeInfo(@TypeOf(val));
+        if (out_info != .Int or in_info != .Int) @compileError("only integer types are supported");
+        if (out_info.Int.bits > in_info.Int.bits) @compileError("out type must be smaller than in type");
+    }
+    const max = std.math.maxInt(T);
+    if (val >= max) return max;
+    return @intCast(T, val);
+}


### PR DESCRIPTION
Currently river will always resize from the bottom right corner of a view when resizing via pointer. This patch makes it possible to "grab" all four corners of a view and resize it in that direction.

Still a bit WIP, but works fine

Still to do:
* [x] cursor position
* [x] min size
* [x] max size
* [x] XDG toplevel resize requests
* [x] single-sided resize modes