### PR TITLE
Cursor: fix pointer input after drags in gtk3 clients

### DIFF
--- a/river/DragIcon.zig
+++ b/river/DragIcon.zig
@@ -24,10 +24,10 @@ const wl = @import("wayland").server.wl;
 const server = &@import("main.zig").server;
 const util = @import("util.zig");
 
-const Seat = @import("Seat.zig");
+const Cursor = @import("Cursor.zig");
 const Subsurface = @import("Subsurface.zig");
 
-seat: *Seat,
+cursor: *Cursor,
 wlr_drag_icon: *wlr.Drag.Icon,
 
 // Always active
@@ -39,8 +39,8 @@ new_subsurface: wl.Listener(*wlr.Subsurface) = wl.Listener(*wlr.Subsurface).init
 // Only active while mapped
 commit: wl.Listener(*wlr.Surface) = wl.Listener(*wlr.Surface).init(handleCommit),
 
-pub fn init(drag_icon: *DragIcon, seat: *Seat, wlr_drag_icon: *wlr.Drag.Icon) void {
-    drag_icon.* = .{ .seat = seat, .wlr_drag_icon = wlr_drag_icon };
+pub fn init(drag_icon: *DragIcon, cursor: *Cursor, wlr_drag_icon: *wlr.Drag.Icon) void {
+    drag_icon.* = .{ .cursor = cursor, .wlr_drag_icon = wlr_drag_icon };
 
     wlr_drag_icon.events.destroy.add(&drag_icon.destroy);
     wlr_drag_icon.events.map.add(&drag_icon.map);

--- a/river/render.zig
+++ b/river/render.zig
@@ -235,9 +235,9 @@ fn renderDragIcons(output: *const Output, now: *os.timespec) void {
 
         var rdata = SurfaceRenderData{
             .output = output,
-            .output_x = @floatToInt(i32, drag_icon.seat.cursor.wlr_cursor.x) +
+            .output_x = @floatToInt(i32, drag_icon.cursor.wlr_cursor.x) +
                 drag_icon.wlr_drag_icon.surface.sx - output_box.x,
-            .output_y = @floatToInt(i32, drag_icon.seat.cursor.wlr_cursor.y) +
+            .output_y = @floatToInt(i32, drag_icon.cursor.wlr_cursor.y) +
                 drag_icon.wlr_drag_icon.surface.sy - output_box.y,
             .when = now,
         };


### PR DESCRIPTION
It seems that either GTK mishandles the case where wl_pointer.enter is
sent before wl_data_source.dnd_finished after performing a dnd
or that sending the events in that order is a protocol error on the
compositor's part.

Edit: the above analysis is at least partially incorrect.