### PR TITLE
Install session desktop file

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -157,6 +157,8 @@ pub fn build(b: *zbs.Builder) !void {
         b.installFile(file, "share/pkgconfig/river-protocols.pc");
     }
 
+    b.installFile("river.desktop", "share/wayland-sessions/river.desktop");
+
     if (man_pages) {
         const scdoc_step = ScdocStep.create(b);
         try scdoc_step.install();

--- a/river.desktop
+++ b/river.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=River
+Comment=A dynamic tiling Wayland compositor
+Exec=river
+Type=Application


### PR DESCRIPTION
Display managers like GDM use these desktop files to show a session selector in the greeter.