### PR TITLE
ext-session-lock: implement protocol

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,6 +88,7 @@ pub fn build(b: *zbs.Builder) !void {
 
     const scanner = ScanProtocolsStep.create(b);
     scanner.addSystemProtocol("stable/xdg-shell/xdg-shell.xml");
+    scanner.addSystemProtocol("staging/ext-session-lock/ext-session-lock-v1.xml");
     scanner.addSystemProtocol("unstable/pointer-gestures/pointer-gestures-unstable-v1.xml");
     scanner.addSystemProtocol("unstable/pointer-constraints/pointer-constraints-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-control-unstable-v1.xml");
@@ -108,6 +109,7 @@ pub fn build(b: *zbs.Builder) !void {
     scanner.generate("xdg_wm_base", 2);
     scanner.generate("zwp_pointer_gestures_v1", 3);
     scanner.generate("zwp_pointer_constraints_v1", 1);
+    scanner.generate("ext_session_lock_manager_v1", 1);
 
     scanner.generate("zriver_control_v1", 1);
     scanner.generate("zriver_status_manager_v1", 3);

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -157,8 +157,8 @@ are ignored by river.
 Mappings are modal in river. Each mapping is associated with a mode and is
 only active while in that mode. There are two special modes: "normal" and
 "locked". The normal mode is the initial mode on startup. The locked mode
-is automatically entered while an input inhibitor (such as a lockscreen)
-is active. It cannot be entered or exited manually.
+is automatically entered while a lock screen is active. It cannot be entered
+or exited manually.
 
 The following modifiers are available for use in mappings:
 

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -154,11 +154,11 @@ are ignored by river.
 
 ## MAPPINGS
 
-Mappings are modal in river. Each mapping is associated with a mode and is
-only active while in that mode. There are two special modes: "normal" and
-"locked". The normal mode is the initial mode on startup. The locked mode
-is automatically entered while a lock screen is active. It cannot be entered
-or exited manually.
+Mappings are modal in river. Each mapping is associated with a mode and
+is only active while in that mode. There are two special modes: "normal"
+and "locked". The normal mode is the initial mode on startup. The locked
+mode is automatically entered while the session is locked (e.g. due to
+a screenlocker). It cannot be entered or exited manually.
 
 The following modifiers are available for use in mappings:
 

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -1064,13 +1064,8 @@ fn passthrough(self: *Self, time: u32) void {
     assert(self.mode == .passthrough);
 
     if (self.surfaceAt()) |result| {
-        // If input is allowed on the surface, send pointer enter and motion
-        // events. Note that wlroots won't actually send an enter event if
-        // the surface has already been entered.
-        if (server.input_manager.inputAllowed(result.surface)) {
-            self.seat.wlr_seat.pointerNotifyEnter(result.surface, result.sx, result.sy);
-            self.seat.wlr_seat.pointerNotifyMotion(time, result.sx, result.sy);
-        }
+        self.seat.wlr_seat.pointerNotifyEnter(result.surface, result.sx, result.sy);
+        self.seat.wlr_seat.pointerNotifyMotion(time, result.sx, result.sy);
     } else {
         // There is either no surface under the cursor or input is disallowed
         // Reset the cursor image to the default and clear focus.

--- a/river/DragIcon.zig
+++ b/river/DragIcon.zig
@@ -72,7 +72,7 @@ fn handleMap(listener: *wl.Listener(*wlr.Drag.Icon), wlr_drag_icon: *wlr.Drag.Ic
 
     wlr_drag_icon.surface.events.commit.add(&drag_icon.commit);
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 fn handleUnmap(listener: *wl.Listener(*wlr.Drag.Icon), _: *wlr.Drag.Icon) void {
@@ -80,12 +80,12 @@ fn handleUnmap(listener: *wl.Listener(*wlr.Drag.Icon), _: *wlr.Drag.Icon) void {
 
     drag_icon.commit.link.remove();
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 fn handleCommit(_: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 fn handleNewSubsurface(listener: *wl.Listener(*wlr.Subsurface), wlr_subsurface: *wlr.Subsurface) void {

--- a/river/LayerSurface.zig
+++ b/river/LayerSurface.zig
@@ -164,7 +164,7 @@ fn handleCommit(listener: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
         server.root.startTransaction();
     }
 
-    self.output.damage.addWhole();
+    self.output.damage.?.addWhole();
 }
 
 fn handleNewPopup(listener: *wl.Listener(*wlr.XdgPopup), wlr_xdg_popup: *wlr.XdgPopup) void {

--- a/river/LockManager.zig
+++ b/river/LockManager.zig
@@ -1,0 +1,124 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2021 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const LockManager = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const wlr = @import("wlroots");
+const wl = @import("wayland").server.wl;
+
+const server = &@import("main.zig").server;
+const util = @import("util.zig");
+
+const LockSurface = @import("LockSurface.zig");
+
+locked: bool = false,
+lock: ?*wlr.SessionLockV1 = null,
+
+new_lock: wl.Listener(*wlr.SessionLockV1) = wl.Listener(*wlr.SessionLockV1).init(handleLock),
+unlock: wl.Listener(void) = wl.Listener(void).init(handleUnlock),
+destroy: wl.Listener(void) = wl.Listener(void).init(handleDestroy),
+new_surface: wl.Listener(*wlr.SessionLockSurfaceV1) =
+    wl.Listener(*wlr.SessionLockSurfaceV1).init(handleSurface),
+
+pub fn init(manager: *LockManager) !void {
+    manager.* = .{};
+    const wlr_manager = try wlr.SessionLockManagerV1.create(server.wl_server);
+    wlr_manager.events.new_lock.add(&manager.new_lock);
+}
+
+pub fn deinit(manager: *LockManager) void {
+    // deinit() should only be called after wl.Server.destroyClients()
+    assert(manager.lock == null);
+
+    manager.new_lock.link.remove();
+}
+
+fn handleLock(listener: *wl.Listener(*wlr.SessionLockV1), lock: *wlr.SessionLockV1) void {
+    const manager = @fieldParentPtr(LockManager, "new_lock", listener);
+
+    if (manager.lock != null) {
+        lock.destroy();
+        return;
+    }
+
+    manager.lock = lock;
+    lock.sendLocked();
+
+    if (!manager.locked) {
+        manager.locked = true;
+
+        var it = server.input_manager.seats.first;
+        while (it) |node| : (it = node.next) {
+            const seat = &node.data;
+            seat.setFocusRaw(.none);
+            seat.cursor.updateState();
+
+            // Enter locked mode
+            seat.prev_mode_id = seat.mode_id;
+            seat.enterMode(1);
+        }
+    }
+
+    lock.events.new_surface.add(&manager.new_surface);
+    lock.events.unlock.add(&manager.unlock);
+    lock.events.destroy.add(&manager.destroy);
+}
+
+fn handleUnlock(listener: *wl.Listener(void)) void {
+    const manager = @fieldParentPtr(LockManager, "unlock", listener);
+
+    assert(manager.locked);
+    manager.locked = false;
+
+    {
+        var it = server.input_manager.seats.first;
+        while (it) |node| : (it = node.next) {
+            const seat = &node.data;
+            seat.setFocusRaw(.none);
+            seat.focus(null);
+            seat.cursor.updateState();
+
+            // Exit locked mode
+            seat.enterMode(seat.prev_mode_id);
+        }
+    }
+
+    handleDestroy(&manager.destroy);
+}
+
+fn handleDestroy(listener: *wl.Listener(void)) void {
+    const manager = @fieldParentPtr(LockManager, "destroy", listener);
+
+    manager.new_surface.link.remove();
+    manager.unlock.link.remove();
+    manager.destroy.link.remove();
+
+    manager.lock = null;
+}
+
+fn handleSurface(
+    listener: *wl.Listener(*wlr.SessionLockSurfaceV1),
+    wlr_lock_surface: *wlr.SessionLockSurfaceV1,
+) void {
+    const manager = @fieldParentPtr(LockManager, "new_surface", listener);
+
+    assert(manager.locked);
+    assert(manager.lock != null);
+
+    LockSurface.create(wlr_lock_surface);
+}

--- a/river/LockManager.zig
+++ b/river/LockManager.zig
@@ -120,5 +120,5 @@ fn handleSurface(
     assert(manager.locked);
     assert(manager.lock != null);
 
-    LockSurface.create(wlr_lock_surface);
+    LockSurface.create(wlr_lock_surface, manager.lock.?);
 }

--- a/river/LockSurface.zig
+++ b/river/LockSurface.zig
@@ -24,17 +24,19 @@ const server = &@import("main.zig").server;
 const util = @import("util.zig");
 
 const Output = @import("Output.zig");
+const Seat = @import("Seat.zig");
 const Subsurface = @import("Subsurface.zig");
 
 wlr_lock_surface: *wlr.SessionLockSurfaceV1,
+lock: *wlr.SessionLockV1,
 
 output_mode: wl.Listener(*wlr.Output) = wl.Listener(*wlr.Output).init(handleOutputMode),
 map: wl.Listener(void) = wl.Listener(void).init(handleMap),
-destroy: wl.Listener(void) = wl.Listener(void).init(handleDestroy),
+surface_destroy: wl.Listener(void) = wl.Listener(void).init(handleDestroy),
 commit: wl.Listener(*wlr.Surface) = wl.Listener(*wlr.Surface).init(handleCommit),
 new_subsurface: wl.Listener(*wlr.Subsurface) = wl.Listener(*wlr.Subsurface).init(handleSubsurface),
 
-pub fn create(wlr_lock_surface: *wlr.SessionLockSurfaceV1) void {
+pub fn create(wlr_lock_surface: *wlr.SessionLockSurfaceV1, lock: *wlr.SessionLockV1) void {
     const lock_surface = util.gpa.create(LockSurface) catch {
         wlr_lock_surface.resource.getClient().postNoMemory();
         return;
@@ -42,16 +44,51 @@ pub fn create(wlr_lock_surface: *wlr.SessionLockSurfaceV1) void {
 
     lock_surface.* = .{
         .wlr_lock_surface = wlr_lock_surface,
+        .lock = lock,
     };
+    wlr_lock_surface.data = @ptrToInt(lock_surface);
+
     wlr_lock_surface.output.events.mode.add(&lock_surface.output_mode);
     wlr_lock_surface.events.map.add(&lock_surface.map);
-    wlr_lock_surface.events.destroy.add(&lock_surface.destroy);
+    wlr_lock_surface.events.destroy.add(&lock_surface.surface_destroy);
     wlr_lock_surface.surface.events.commit.add(&lock_surface.commit);
     wlr_lock_surface.surface.events.new_subsurface.add(&lock_surface.new_subsurface);
 
     handleOutputMode(&lock_surface.output_mode, wlr_lock_surface.output);
 
     Subsurface.handleExisting(wlr_lock_surface.surface, .{ .lock_surface = lock_surface });
+}
+
+pub fn destroy(lock_surface: *LockSurface) void {
+    lock_surface.output().lock_surface = null;
+    if (lock_surface.output().damage) |damage| damage.addWhole();
+
+    {
+        var surface_it = lock_surface.lock.surfaces.iterator(.forward);
+        const new_focus: Seat.FocusTarget = while (surface_it.next()) |surface| {
+            if (surface != lock_surface.wlr_lock_surface)
+                break .{ .lock_surface = @intToPtr(*LockSurface, surface.data) };
+        } else .none;
+
+        var seat_it = server.input_manager.seats.first;
+        while (seat_it) |node| : (seat_it = node.next) {
+            const seat = &node.data;
+            if (seat.focused == .lock_surface and seat.focused.lock_surface == lock_surface) {
+                seat.setFocusRaw(new_focus);
+            }
+            seat.cursor.updateState();
+        }
+    }
+
+    lock_surface.output_mode.link.remove();
+    lock_surface.map.link.remove();
+    lock_surface.surface_destroy.link.remove();
+    lock_surface.commit.link.remove();
+    lock_surface.new_subsurface.link.remove();
+
+    Subsurface.destroySubsurfaces(lock_surface.wlr_lock_surface.surface);
+
+    util.gpa.destroy(lock_surface);
 }
 
 pub fn output(lock_surface: *LockSurface) *Output {
@@ -84,37 +121,15 @@ fn handleMap(listener: *wl.Listener(void)) void {
 }
 
 fn handleDestroy(listener: *wl.Listener(void)) void {
-    const lock_surface = @fieldParentPtr(LockSurface, "destroy", listener);
+    const lock_surface = @fieldParentPtr(LockSurface, "surface_destroy", listener);
 
-    lock_surface.output().lock_surface = null;
-    lock_surface.output().damage.addWhole();
-
-    {
-        var it = server.input_manager.seats.first;
-        while (it) |node| : (it = node.next) {
-            const seat = &node.data;
-            if (seat.focused == .lock_surface and seat.focused.lock_surface == lock_surface) {
-                seat.setFocusRaw(.none);
-            }
-            seat.cursor.updateState();
-        }
-    }
-
-    lock_surface.output_mode.link.remove();
-    lock_surface.map.link.remove();
-    lock_surface.destroy.link.remove();
-    lock_surface.commit.link.remove();
-    lock_surface.new_subsurface.link.remove();
-
-    Subsurface.destroySubsurfaces(lock_surface.wlr_lock_surface.surface);
-
-    util.gpa.destroy(lock_surface);
+    lock_surface.destroy();
 }
 
 fn handleCommit(listener: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
     const lock_surface = @fieldParentPtr(LockSurface, "commit", listener);
 
-    lock_surface.output().damage.addWhole();
+    lock_surface.output().damage.?.addWhole();
 }
 
 fn handleSubsurface(listener: *wl.Listener(*wlr.Subsurface), subsurface: *wlr.Subsurface) void {

--- a/river/LockSurface.zig
+++ b/river/LockSurface.zig
@@ -107,6 +107,8 @@ fn handleOutputMode(listener: *wl.Listener(*wlr.Output), _: *wlr.Output) void {
 fn handleMap(listener: *wl.Listener(void)) void {
     const lock_surface = @fieldParentPtr(LockSurface, "map", listener);
 
+    lock_surface.output().lock_surface = lock_surface;
+
     {
         var it = server.input_manager.seats.first;
         while (it) |node| : (it = node.next) {
@@ -114,10 +116,9 @@ fn handleMap(listener: *wl.Listener(void)) void {
             if (seat.focused != .lock_surface) {
                 seat.setFocusRaw(.{ .lock_surface = lock_surface });
             }
+            seat.cursor.updateState();
         }
     }
-
-    lock_surface.output().lock_surface = lock_surface;
 }
 
 fn handleDestroy(listener: *wl.Listener(void)) void {

--- a/river/LockSurface.zig
+++ b/river/LockSurface.zig
@@ -1,0 +1,123 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2021 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const LockSurface = @This();
+
+const std = @import("std");
+const wlr = @import("wlroots");
+const wl = @import("wayland").server.wl;
+
+const server = &@import("main.zig").server;
+const util = @import("util.zig");
+
+const Output = @import("Output.zig");
+const Subsurface = @import("Subsurface.zig");
+
+wlr_lock_surface: *wlr.SessionLockSurfaceV1,
+
+output_mode: wl.Listener(*wlr.Output) = wl.Listener(*wlr.Output).init(handleOutputMode),
+map: wl.Listener(void) = wl.Listener(void).init(handleMap),
+destroy: wl.Listener(void) = wl.Listener(void).init(handleDestroy),
+commit: wl.Listener(*wlr.Surface) = wl.Listener(*wlr.Surface).init(handleCommit),
+new_subsurface: wl.Listener(*wlr.Subsurface) = wl.Listener(*wlr.Subsurface).init(handleSubsurface),
+
+pub fn create(wlr_lock_surface: *wlr.SessionLockSurfaceV1) void {
+    const lock_surface = util.gpa.create(LockSurface) catch {
+        wlr_lock_surface.resource.getClient().postNoMemory();
+        return;
+    };
+
+    lock_surface.* = .{
+        .wlr_lock_surface = wlr_lock_surface,
+    };
+    wlr_lock_surface.output.events.mode.add(&lock_surface.output_mode);
+    wlr_lock_surface.events.map.add(&lock_surface.map);
+    wlr_lock_surface.events.destroy.add(&lock_surface.destroy);
+    wlr_lock_surface.surface.events.commit.add(&lock_surface.commit);
+    wlr_lock_surface.surface.events.new_subsurface.add(&lock_surface.new_subsurface);
+
+    handleOutputMode(&lock_surface.output_mode, wlr_lock_surface.output);
+
+    Subsurface.handleExisting(wlr_lock_surface.surface, .{ .lock_surface = lock_surface });
+}
+
+pub fn output(lock_surface: *LockSurface) *Output {
+    return @intToPtr(*Output, lock_surface.wlr_lock_surface.output.data);
+}
+
+fn handleOutputMode(listener: *wl.Listener(*wlr.Output), _: *wlr.Output) void {
+    const lock_surface = @fieldParentPtr(LockSurface, "output_mode", listener);
+
+    var output_width: i32 = undefined;
+    var output_height: i32 = undefined;
+    lock_surface.output().wlr_output.effectiveResolution(&output_width, &output_height);
+    _ = lock_surface.wlr_lock_surface.configure(@intCast(u32, output_width), @intCast(u32, output_height));
+}
+
+fn handleMap(listener: *wl.Listener(void)) void {
+    const lock_surface = @fieldParentPtr(LockSurface, "map", listener);
+
+    {
+        var it = server.input_manager.seats.first;
+        while (it) |node| : (it = node.next) {
+            const seat = &node.data;
+            if (seat.focused != .lock_surface) {
+                seat.setFocusRaw(.{ .lock_surface = lock_surface });
+            }
+        }
+    }
+
+    lock_surface.output().lock_surface = lock_surface;
+}
+
+fn handleDestroy(listener: *wl.Listener(void)) void {
+    const lock_surface = @fieldParentPtr(LockSurface, "destroy", listener);
+
+    lock_surface.output().lock_surface = null;
+    lock_surface.output().damage.addWhole();
+
+    {
+        var it = server.input_manager.seats.first;
+        while (it) |node| : (it = node.next) {
+            const seat = &node.data;
+            if (seat.focused == .lock_surface and seat.focused.lock_surface == lock_surface) {
+                seat.setFocusRaw(.none);
+            }
+            seat.cursor.updateState();
+        }
+    }
+
+    lock_surface.output_mode.link.remove();
+    lock_surface.map.link.remove();
+    lock_surface.destroy.link.remove();
+    lock_surface.commit.link.remove();
+    lock_surface.new_subsurface.link.remove();
+
+    Subsurface.destroySubsurfaces(lock_surface.wlr_lock_surface.surface);
+
+    util.gpa.destroy(lock_surface);
+}
+
+fn handleCommit(listener: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
+    const lock_surface = @fieldParentPtr(LockSurface, "commit", listener);
+
+    lock_surface.output().damage.addWhole();
+}
+
+fn handleSubsurface(listener: *wl.Listener(*wlr.Subsurface), subsurface: *wlr.Subsurface) void {
+    const lock_surface = @fieldParentPtr(LockSurface, "new_subsurface", listener);
+    Subsurface.create(subsurface, .{ .lock_surface = lock_surface });
+}

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -55,7 +55,7 @@ const State = struct {
 };
 
 wlr_output: *wlr.Output,
-damage: *wlr.OutputDamage,
+damage: ?*wlr.OutputDamage,
 
 /// All layer surfaces on the output, indexed by the layer enum.
 layers: [4]std.TailQueue(LayerSurface) = [1]std.TailQueue(LayerSurface){.{}} ** 4,
@@ -136,8 +136,8 @@ pub fn init(self: *Self, wlr_output: *wlr.Output) !void {
     wlr_output.events.enable.add(&self.enable);
     wlr_output.events.mode.add(&self.mode);
 
-    self.damage.events.frame.add(&self.frame);
-    self.damage.events.destroy.add(&self.damage_destroy);
+    self.damage.?.events.frame.add(&self.frame);
+    self.damage.?.events.destroy.add(&self.damage_destroy);
 
     // Ensure that a cursor image at the output's scale factor is loaded
     // for each seat.
@@ -431,6 +431,8 @@ fn handleDamageDestroy(listener: *wl.Listener(*wlr.OutputDamage), _: *wlr.Output
     self.frame.link.remove();
     // Ensure that it is safe to call remove() again in handleDestroy()
     self.frame.link = .{ .prev = &self.frame.link, .next = &self.frame.link };
+
+    self.damage = null;
 }
 
 fn handleDestroy(listener: *wl.Listener(*wlr.Output), _: *wlr.Output) void {
@@ -451,6 +453,8 @@ fn handleDestroy(listener: *wl.Listener(*wlr.Output), _: *wlr.Output) void {
             break;
         }
     }
+
+    if (self.lock_surface) |surface| surface.destroy();
 
     // Remove all listeners
     self.destroy.link.remove();

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -33,6 +33,7 @@ const util = @import("util.zig");
 const LayerSurface = @import("LayerSurface.zig");
 const Layout = @import("Layout.zig");
 const LayoutDemand = @import("LayoutDemand.zig");
+const LockSurface = @import("LockSurface.zig");
 const View = @import("View.zig");
 const ViewStack = @import("view_stack.zig").ViewStack;
 const OutputStatus = @import("OutputStatus.zig");
@@ -66,6 +67,8 @@ usable_box: wlr.Box,
 
 /// The top of the stack is the "most important" view.
 views: ViewStack(View) = .{},
+
+lock_surface: ?*LockSurface = null,
 
 /// The double-buffered state of the output.
 current: State = State{ .tags = 1 << 0 },

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -392,7 +392,7 @@ fn commitTransaction(self: *Self) void {
         if (view_tags_changed) output.sendViewTags();
         if (urgent_tags_dirty) output.sendUrgentTags();
 
-        output.damage.addWhole();
+        output.damage.?.addWhole();
     }
     server.input_manager.updateCursorState();
     server.idle_inhibitor_manager.idleInhibitCheckActive();

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -47,7 +47,7 @@ const XwaylandOverrideRedirect = @import("XwaylandOverrideRedirect.zig");
 const log = std.log.scoped(.seat);
 const PointerConstraint = @import("PointerConstraint.zig");
 
-const FocusTarget = union(enum) {
+pub const FocusTarget = union(enum) {
     view: *View,
     xwayland_override_redirect: *XwaylandOverrideRedirect,
     layer: *LayerSurface,

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -30,6 +30,7 @@ const DecorationManager = @import("DecorationManager.zig");
 const InputManager = @import("InputManager.zig");
 const LayerSurface = @import("LayerSurface.zig");
 const LayoutManager = @import("LayoutManager.zig");
+const LockManager = @import("LockManager.zig");
 const Output = @import("Output.zig");
 const Root = @import("Root.zig");
 const StatusManager = @import("StatusManager.zig");
@@ -71,6 +72,7 @@ control: Control,
 status_manager: StatusManager,
 layout_manager: LayoutManager,
 idle_inhibitor_manager: IdleInhibitorManager,
+lock_manager: LockManager,
 
 pub fn init(self: *Self) !void {
     self.wl_server = try wl.Server.create();
@@ -127,6 +129,7 @@ pub fn init(self: *Self) !void {
     try self.status_manager.init();
     try self.layout_manager.init();
     try self.idle_inhibitor_manager.init(self.input_manager.idle);
+    try self.lock_manager.init();
 
     // These all free themselves when the wl_server is destroyed
     _ = try wlr.DataDeviceManager.create(self.wl_server);
@@ -153,6 +156,7 @@ pub fn deinit(self: *Self) void {
     self.root.deinit();
     self.input_manager.deinit();
     self.idle_inhibitor_manager.deinit();
+    self.lock_manager.deinit();
 
     self.wl_server.destroy();
 

--- a/river/Subsurface.zig
+++ b/river/Subsurface.zig
@@ -37,12 +37,12 @@ pub const Parent = union(enum) {
 
     pub fn damageWholeOutput(parent: Parent) void {
         switch (parent) {
-            .xdg_toplevel => |xdg_toplevel| xdg_toplevel.view.output.damage.addWhole(),
-            .layer_surface => |layer_surface| layer_surface.output.damage.addWhole(),
-            .lock_surface => |lock_surface| lock_surface.output().damage.addWhole(),
+            .xdg_toplevel => |xdg_toplevel| xdg_toplevel.view.output.damage.?.addWhole(),
+            .layer_surface => |layer_surface| layer_surface.output.damage.?.addWhole(),
+            .lock_surface => |lock_surface| lock_surface.output().damage.?.addWhole(),
             .drag_icon => |_| {
                 var it = server.root.outputs.first;
-                while (it) |node| : (it = node.next) node.data.damage.addWhole();
+                while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
             },
         }
     }

--- a/river/Subsurface.zig
+++ b/river/Subsurface.zig
@@ -26,17 +26,20 @@ const util = @import("util.zig");
 
 const DragIcon = @import("DragIcon.zig");
 const LayerSurface = @import("LayerSurface.zig");
+const LockSurface = @import("LockSurface.zig");
 const XdgToplevel = @import("XdgToplevel.zig");
 
 pub const Parent = union(enum) {
     xdg_toplevel: *XdgToplevel,
     layer_surface: *LayerSurface,
+    lock_surface: *LockSurface,
     drag_icon: *DragIcon,
 
     pub fn damageWholeOutput(parent: Parent) void {
         switch (parent) {
             .xdg_toplevel => |xdg_toplevel| xdg_toplevel.view.output.damage.addWhole(),
             .layer_surface => |layer_surface| layer_surface.output.damage.addWhole(),
+            .lock_surface => |lock_surface| lock_surface.output().damage.addWhole(),
             .drag_icon => |_| {
                 var it = server.root.outputs.first;
                 while (it) |node| : (it = node.next) node.data.damage.addWhole();

--- a/river/XdgPopup.zig
+++ b/river/XdgPopup.zig
@@ -76,7 +76,7 @@ pub fn create(wlr_xdg_popup: *wlr.XdgPopup, parent: Parent) void {
             layer_surface.output.wlr_output.effectiveResolution(&box.width, &box.height);
             wlr_xdg_popup.unconstrainFromBox(&box);
         },
-        .drag_icon => unreachable,
+        .drag_icon, .lock_surface => unreachable,
     }
 
     wlr_xdg_popup.base.events.destroy.add(&xdg_popup.surface_destroy);

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -298,7 +298,7 @@ fn handleCommit(listener: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
                 // before some change occured that caused shouldTrackConfigure() to return false.
                 view.dropSavedBuffers();
 
-                view.output.damage.addWhole();
+                view.output.damage.?.addWhole();
                 server.input_manager.updateCursorState();
             }
         } else {
@@ -309,7 +309,7 @@ fn handleCommit(listener: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
             view.sendFrameDone();
         }
     } else {
-        view.output.damage.addWhole();
+        view.output.damage.?.addWhole();
         const size_changed = !std.meta.eql(view.surface_box, new_box);
         view.surface_box = new_box;
         // If the client has decided to resize itself and the view is floating,

--- a/river/XwaylandOverrideRedirect.zig
+++ b/river/XwaylandOverrideRedirect.zig
@@ -130,7 +130,7 @@ fn handleUnmap(listener: *wl.Listener(*wlr.XwaylandSurface), _: *wlr.XwaylandSur
 
 fn handleCommit(_: *wl.Listener(*wlr.Surface), _: *wlr.Surface) void {
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 fn handleSetOverrideRedirect(

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -300,7 +300,7 @@ fn handleSetOverrideRedirect(
 fn handleCommit(listener: *wl.Listener(*wlr.Surface), surface: *wlr.Surface) void {
     const self = @fieldParentPtr(Self, "commit", listener);
 
-    self.view.output.damage.addWhole();
+    self.view.output.damage.?.addWhole();
 
     self.view.surface_box = .{
         .x = 0,

--- a/river/command/config.zig
+++ b/river/command/config.zig
@@ -48,7 +48,7 @@ pub fn backgroundColor(
     server.config.background_color = try parseRgba(args[1]);
 
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 pub fn borderColorFocused(
@@ -62,7 +62,7 @@ pub fn borderColorFocused(
     server.config.border_color_focused = try parseRgba(args[1]);
 
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 pub fn borderColorUnfocused(
@@ -76,7 +76,7 @@ pub fn borderColorUnfocused(
     server.config.border_color_unfocused = try parseRgba(args[1]);
 
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 pub fn borderColorUrgent(
@@ -90,7 +90,7 @@ pub fn borderColorUrgent(
     server.config.border_color_urgent = try parseRgba(args[1]);
 
     var it = server.root.outputs.first;
-    while (it) |node| : (it = node.next) node.data.damage.addWhole();
+    while (it) |node| : (it = node.next) node.data.damage.?.addWhole();
 }
 
 pub fn setCursorWarp(

--- a/river/render.zig
+++ b/river/render.zig
@@ -51,7 +51,7 @@ pub fn renderOutput(output: *Output) void {
     var damage_region: pixman.Region32 = undefined;
     damage_region.init();
     defer damage_region.deinit();
-    output.damage.attachRender(&needs_frame, &damage_region) catch {
+    output.damage.?.attachRender(&needs_frame, &damage_region) catch {
         log.err("failed to attach renderer", .{});
         return;
     };


### PR DESCRIPTION
- [x] Protocol merged to wayland-protocols https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/131
- [x] wlroots implementation merged https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3414
- [x] wayland-protocols release
- [x] wlroots release

Since river tracks the latest wlroots releases, I've cherry-picked the wlroots commit linked above onto the 0.15.0 tag for testing. Branch here: https://gitlab.freedesktop.org/ifreund/wlroots/-/tree/session-lock-0.15

This can be tested with the swaylock implementation of this protocol here: https://github.com/swaywm/swaylock/pull/219