### PR TITLE
Implement a scroll-factor command

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -40,6 +40,8 @@ const View = @import("View.zig");
 const ViewStack = @import("view_stack.zig").ViewStack;
 const XwaylandUnmanaged = @import("XwaylandUnmanaged.zig");
 
+const InputConfig = @import("InputConfig.zig");
+
 const Mode = union(enum) {
     passthrough: void,
     down: struct {
@@ -247,12 +249,14 @@ fn handleAxis(listener: *wl.Listener(*wlr.Pointer.event.Axis), event: *wlr.Point
 
     self.seat.handleActivity();
 
+    const scroll_factor = server.input_manager.input_configs.scroll_factor || 1.0;
+
     // Notify the client with pointer focus of the axis event.
     self.seat.wlr_seat.pointerNotifyAxis(
         event.time_msec,
         event.orientation,
-        event.delta,
-        event.delta_discrete,
+        scroll_factor * event.delta,
+        @floatToInt(i32, scroll_factor * @intToFloat(f64, event.delta_discrete)),
         event.source,
     );
 }

--- a/river/InputConfig.zig
+++ b/river/InputConfig.zig
@@ -265,6 +265,10 @@ pub const ScrollButton = struct {
     }
 };
 
+pub const ScrollFactor = struct {
+    value: f64
+};
+
 identifier: []const u8,
 
 event_state: ?EventState = null,
@@ -281,6 +285,7 @@ tap_button_map: ?TapButtonMap = null,
 pointer_accel: ?PointerAccel = null,
 scroll_method: ?ScrollMethod = null,
 scroll_button: ?ScrollButton = null,
+scroll_factor: ?ScrollFactor = null,
 
 pub fn deinit(self: *Self) void {
     util.gpa.free(self.identifier);

--- a/river/command/input.zig
+++ b/river/command/input.zig
@@ -204,6 +204,10 @@ pub fn input(
         const ret = c.libevdev_event_code_from_name(c.EV_KEY, args[3]);
         if (ret < 1) return Error.InvalidButton;
         input_config.scroll_button = InputConfig.ScrollButton{ .button = @intCast(u32, ret) };
+    } else if (mem.eql(u8, "scroll-factor", args[2])) {
+        input_config.scroll_factor = InputConfig.ScrollFactor{
+            .value = std.math.fabs(try std.fmt.parseFloat(f64, args[3])),
+        };
     } else {
         return Error.UnknownCommand;
     }


### PR DESCRIPTION
This PR implements a `scroll-factor` input setting that allows to control scroll speed

See https://github.com/swaywm/sway/pull/3018:

> This PR adds a scroll_factor input command whose value is used as a multiplier for axis event deltas received from a device.  Put simply, this means that scrolling speed can now be adjusted, a configuration feature that libinput itself lacks. At least on my laptop's touchpad, such a change is sorely needed.
>
>For example, adding scroll_factor 0.5 under a device's input section will make scrolling half as fast.

