### PR TITLE
contrib: add desktop file

### DIFF
--- a/contrib/river.desktop
+++ b/contrib/river.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=River
+Comment=A dynamic tiling Wayland compositor
+Exec=river
+Type=Application


### PR DESCRIPTION
I recently made a river Debian package and included a desktop file to be installed in /usr/share/wayland-sessions. I noticed that the river-git AUR package does the same thing, So, to avoid duplicating work and to keep things consistent between distributions, I thought it would be worthwhile if upstream river shipped with a desktop file that all packagers could make use of. This desktop file in this branch is almost identical to the one from AUR river-git differing only in the capitalization for "River" and in the addition of a newline at the end of the file.