### PR TITLE
rivertile: Use saturating addtion

### DIFF
--- a/rivertile/main.zig
+++ b/rivertile/main.zig
@@ -170,11 +170,7 @@ const Output = struct {
                             return;
                         };
                         switch (raw_arg[0]) {
-                            '+' => output.main_count = math.add(
-                                u32,
-                                output.main_count,
-                                @intCast(u32, arg),
-                            ) catch math.maxInt(u32),
+                            '+' => output.main_count +|= @intCast(u32, arg),
                             '-' => {
                                 const result = @as(i33, output.main_count) + arg;
                                 if (result >= 0) output.main_count = @intCast(u32, result);


### PR DESCRIPTION
As far as I could tell this is the only occurrence where we can replace it. Grepping around, the only other case of `maxInt(T)` are use to set a value. Grepping for `math` also doesn't return any `math.mul/add/...`