### PR TITLE
Don't stop applying input configs after first match.

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -293,6 +293,8 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 
 The _input_ command can be used to create a configuration rule for an input
 device identified by its _name_.
+The _name_ of an input device consists of its type, its numerical vendor id,
+its numerical product id and finally its self-advertised name, separated by -.
 
 A list of all device properties that can be configured maybe found below.
 However note that not every input device supports every property.

--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -46,11 +46,15 @@ pub const InputDevice = struct {
     identifier: []const u8,
 
     pub fn init(self: *InputDevice, device: *wlr.InputDevice) !void {
-        // The identifier is formatted exactly as in Sway
         const identifier = try std.fmt.allocPrint(
             util.gpa,
-            "{}:{}:{s}",
-            .{ device.vendor, device.product, mem.trim(u8, mem.span(device.name), &ascii.spaces) },
+            "{s}-{}-{}-{s}",
+            .{
+                @tagName(device.type),
+                device.vendor,
+                device.product,
+                mem.trim(u8, mem.span(device.name), &ascii.spaces),
+            },
         );
         for (identifier) |*char| {
             if (char.* == ' ' or !std.ascii.isPrint(char.*)) {

--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -235,7 +235,6 @@ fn handleNewInput(listener: *wl.Listener(*wlr.InputDevice), device: *wlr.InputDe
     for (self.input_configs.items) |*input_config| {
         if (mem.eql(u8, input_config.identifier, input_device_node.data.identifier)) {
             input_config.apply(&input_device_node.data);
-            break; // There will only ever be one InputConfig for any unique identifier;
         }
     }
 }


### PR DESCRIPTION
A conversation on IRC showed me that device names aren't so unique after all and that multiple devices with the exact same name can be encountered in the real world.

Currently, river will apply an output config to the first input device with a matching device name. Input devices sharing the same name will not get the configuration because the loop `break`'s, which this patch changes.

Maybe we can instead make the names more unique. This however needs to be implemented in a way so that device names still stay consistent between sessions, so for example we can not just prefix them with a counter. Perhaps we can prefix them with the device type (like `touchpad:000:000:company-touchpad-something`), but that would still break if there are multiple devices with the same name of the same type. Also we'd loose input device name compatibility with Sway, which I think would be unfortunate.

Input and thoughts on this are welcome.