### PR TITLE
Mode: Use ArrayListUnmanaged to save memory

### DIFF
--- a/river/Mode.zig
+++ b/river/Mode.zig
@@ -22,19 +22,11 @@ const util = @import("util.zig");
 const Mapping = @import("Mapping.zig");
 const PointerMapping = @import("PointerMapping.zig");
 
-// TODO: use unmanaged array lists here to save memory
-mappings: std.ArrayList(Mapping),
-pointer_mappings: std.ArrayList(PointerMapping),
+mappings: std.ArrayListUnmanaged(Mapping) = .{},
+pointer_mappings: std.ArrayListUnmanaged(PointerMapping) = .{},
 
-pub fn init() Self {
-    return .{
-        .mappings = std.ArrayList(Mapping).init(util.gpa),
-        .pointer_mappings = std.ArrayList(PointerMapping).init(util.gpa),
-    };
-}
-
-pub fn deinit(self: Self) void {
+pub fn deinit(self: *Self) void {
     for (self.mappings.items) |m| m.deinit();
-    self.mappings.deinit();
-    self.pointer_mappings.deinit();
+    self.mappings.deinit(util.gpa);
+    self.pointer_mappings.deinit(util.gpa);
 }

--- a/river/command/declare_mode.zig
+++ b/river/command/declare_mode.zig
@@ -39,9 +39,9 @@ pub fn declareMode(
 
     if (config.mode_to_id.get(new_mode_name) != null) return;
 
-    try config.modes.ensureUnusedCapacity(1);
+    try config.modes.ensureUnusedCapacity(util.gpa, 1);
     const owned_name = try util.gpa.dupe(u8, new_mode_name);
     errdefer util.gpa.free(owned_name);
     try config.mode_to_id.putNoClobber(owned_name, config.modes.items.len);
-    config.modes.appendAssumeCapacity(Mode.init());
+    config.modes.appendAssumeCapacity(.{});
 }

--- a/river/command/map.zig
+++ b/river/command/map.zig
@@ -73,7 +73,7 @@ pub fn map(
         // possible crash if the Mapping ArrayList is reallocated, stop any
         // currently repeating mappings.
         seat.clearRepeatingMapping();
-        try mode_mappings.append(new);
+        try mode_mappings.append(util.gpa, new);
     }
 }
 
@@ -117,7 +117,7 @@ pub fn mapPointer(
     if (pointerMappingExists(mode_pointer_mappings, modifiers, event_code)) |current| {
         mode_pointer_mappings.items[current] = new;
     } else {
-        try mode_pointer_mappings.append(new);
+        try mode_pointer_mappings.append(util.gpa, new);
     }
 }
 
@@ -135,7 +135,7 @@ fn modeNameToId(allocator: std.mem.Allocator, mode_name: []const u8, out: *?[]co
 
 /// Returns the index of the Mapping with matching modifiers, keysym and release, if any.
 fn mappingExists(
-    mappings: *std.ArrayList(Mapping),
+    mappings: *std.ArrayListUnmanaged(Mapping),
     modifiers: wlr.Keyboard.ModifierMask,
     keysym: xkb.Keysym,
     release: bool,
@@ -151,7 +151,7 @@ fn mappingExists(
 
 /// Returns the index of the PointerMapping with matching modifiers and event code, if any.
 fn pointerMappingExists(
-    pointer_mappings: *std.ArrayList(PointerMapping),
+    pointer_mappings: *std.ArrayListUnmanaged(PointerMapping),
     modifiers: wlr.Keyboard.ModifierMask,
     event_code: u32,
 ) ?usize {


### PR DESCRIPTION
- Use ArrayListUnmanaged for `Mode.mappings` and `Mode.pointer_mappings` and also for `Config.Mode`.

- Remove `Mode.init()` as the array list can be directly initialized in `Config.init()`, could be added back if any objection. But imo unless I missed something this doesn't seems to be really useful:
``` zig 
pub fn init() Self {
    return .{
        .mappings = .{},
        .pointer_mappings = .{},
    };
}
```
