### PR TITLE
code: Cleanup use of std library for consistancy

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -138,7 +138,7 @@ pub fn build(b: *zbs.Builder) !void {
 
     {
         const file = try fs.path.join(b.allocator, &[_][]const u8{ b.cache_root, "river-protocols.pc" });
-        const pkgconfig_file = try std.fs.cwd().createFile(file, .{});
+        const pkgconfig_file = try fs.cwd().createFile(file, .{});
 
         const writer = pkgconfig_file.writer();
         try writer.print(

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -267,7 +267,7 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
     self.seat.handleActivity();
 
     if (event.state == .released) {
-        std.debug.assert(self.pressed_count > 0);
+        assert(self.pressed_count > 0);
         self.pressed_count -= 1;
         if (self.pressed_count == 0 and self.mode != .passthrough) {
             self.leaveMode(event);

--- a/river/Decoration.zig
+++ b/river/Decoration.zig
@@ -17,7 +17,6 @@
 const Self = @This();
 
 const std = @import("std");
-const mem = std.mem;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;
 

--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -57,7 +57,7 @@ pub const InputDevice = struct {
             },
         );
         for (identifier) |*char| {
-            if (char.* == ' ' or !std.ascii.isPrint(char.*)) {
+            if (char.* == ' ' or !ascii.isPrint(char.*)) {
                 char.* = '_';
             }
         }

--- a/river/Layout.zig
+++ b/river/Layout.zig
@@ -17,6 +17,7 @@
 const Self = @This();
 
 const std = @import("std");
+const assert = std.debug.assert;
 const mem = std.mem;
 const wlr = @import("wlroots");
 const wayland = @import("wayland");
@@ -102,7 +103,7 @@ pub fn startLayoutDemand(self: *Self, views: u32) void {
         .{ self.namespace, self.output.wlr_output.name },
     );
 
-    std.debug.assert(self.output.layout_demand == null);
+    assert(self.output.layout_demand == null);
     self.output.layout_demand = LayoutDemand.init(self, views) catch {
         log.err("failed starting layout demand", .{});
         return;

--- a/river/LayoutDemand.zig
+++ b/river/LayoutDemand.zig
@@ -18,7 +18,6 @@ const Self = @This();
 
 const std = @import("std");
 const assert = std.debug.assert;
-const mem = std.mem;
 const wlr = @import("wlroots");
 const wayland = @import("wayland");
 const wl = wayland.server.wl;

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -18,7 +18,6 @@ const Self = @This();
 
 const build_options = @import("build_options");
 const std = @import("std");
-const mem = std.mem;
 const assert = std.debug.assert;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -225,12 +225,12 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
         // Set the new focus
         switch (new_focus) {
             .view => |target_view| {
-                std.debug.assert(self.focused_output == target_view.output);
+                assert(self.focused_output == target_view.output);
                 if (target_view.pending.focus == 0) target_view.setActivated(true);
                 target_view.pending.focus += 1;
                 target_view.pending.urgent = false;
             },
-            .layer => |target_layer| std.debug.assert(self.focused_output == target_layer.output),
+            .layer => |target_layer| assert(self.focused_output == target_layer.output),
             .none => {},
         }
         self.focused = new_focus;

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -18,7 +18,6 @@ const Self = @This();
 
 const build_options = @import("build_options");
 const std = @import("std");
-const mem = std.mem;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;
 

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -17,7 +17,7 @@
 const Self = @This();
 
 const std = @import("std");
-const mem = std.mem;
+const math = std.math;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;
 
@@ -143,10 +143,10 @@ pub fn getAppId(self: Self) ?[*:0]const u8 {
 pub fn getConstraints(self: Self) View.Constraints {
     const state = &self.xdg_surface.role_data.toplevel.current;
     return .{
-        .min_width = std.math.max(state.min_width, View.min_size),
-        .max_width = if (state.max_width > 0) state.max_width else std.math.maxInt(u32),
-        .min_height = std.math.max(state.min_height, View.min_size),
-        .max_height = if (state.max_height > 0) state.max_height else std.math.maxInt(u32),
+        .min_width = math.max(state.min_width, View.min_size),
+        .max_width = if (state.max_width > 0) state.max_width else math.maxInt(u32),
+        .min_height = math.max(state.min_height, View.min_size),
+        .max_height = if (state.max_height > 0) state.max_height else math.maxInt(u32),
     };
 }
 
@@ -186,9 +186,9 @@ fn handleMap(listener: *wl.Listener(*wlr.XdgSurface), xdg_surface: *wlr.XdgSurfa
     self.xdg_surface.getGeometry(&initial_box);
     view.float_box.width = @intCast(u32, initial_box.width);
     view.float_box.height = @intCast(u32, initial_box.height);
-    view.float_box.x = std.math.max(0, @divTrunc(@intCast(i32, view.output.usable_box.width) -
+    view.float_box.x = math.max(0, @divTrunc(@intCast(i32, view.output.usable_box.width) -
         @intCast(i32, view.float_box.width), 2));
-    view.float_box.y = std.math.max(0, @divTrunc(@intCast(i32, view.output.usable_box.height) -
+    view.float_box.y = math.max(0, @divTrunc(@intCast(i32, view.output.usable_box.height) -
         @intCast(i32, view.float_box.height), 2));
 
     // We initialize these to avoid special-casing newly mapped views in

--- a/river/command.zig
+++ b/river/command.zig
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const assert = std.debug.assert;
 
 const Seat = @import("Seat.zig");
 
@@ -122,7 +123,7 @@ pub fn run(
     args: []const [:0]const u8,
     out: *?[]const u8,
 ) Error!void {
-    std.debug.assert(out.* == null);
+    assert(out.* == null);
     if (args.len == 0) return Error.NoCommand;
     const impl_fn = command_impls.get(args[0]) orelse return Error.UnknownCommand;
     try impl_fn(allocator, seat, args, out);

--- a/river/command/attach_mode.zig
+++ b/river/command/attach_mode.zig
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const mem = std.mem;
 
 const util = @import("../util.zig");
 
@@ -24,7 +25,7 @@ const Error = @import("../command.zig").Error;
 const Seat = @import("../Seat.zig");
 
 pub fn attachMode(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -32,9 +33,9 @@ pub fn attachMode(
     if (args.len < 2) return Error.NotEnoughArguments;
     if (args.len > 2) return Error.TooManyArguments;
 
-    if (std.mem.eql(u8, "top", args[1])) {
+    if (mem.eql(u8, "top", args[1])) {
         server.config.attach_mode = .top;
-    } else if (std.mem.eql(u8, "bottom", args[1])) {
+    } else if (mem.eql(u8, "bottom", args[1])) {
         server.config.attach_mode = .bottom;
     } else {
         return Error.UnknownOption;

--- a/river/command/config.zig
+++ b/river/command/config.zig
@@ -16,6 +16,7 @@
 
 const std = @import("std");
 const fmt = std.fmt;
+const mem = std.mem;
 
 const server = &@import("../main.zig").server;
 
@@ -24,7 +25,7 @@ const Seat = @import("../Seat.zig");
 const Config = @import("../Config.zig");
 
 pub fn borderWidth(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -38,7 +39,7 @@ pub fn borderWidth(
 }
 
 pub fn backgroundColor(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -53,7 +54,7 @@ pub fn backgroundColor(
 }
 
 pub fn borderColorFocused(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -68,7 +69,7 @@ pub fn borderColorFocused(
 }
 
 pub fn borderColorUnfocused(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -83,7 +84,7 @@ pub fn borderColorUnfocused(
 }
 
 pub fn borderColorUrgent(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -98,7 +99,7 @@ pub fn borderColorUrgent(
 }
 
 pub fn setCursorWarp(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,

--- a/river/command/input.zig
+++ b/river/command/input.zig
@@ -16,6 +16,7 @@
 
 const std = @import("std");
 const mem = std.mem;
+const meta = std.meta;
 
 const server = &@import("../main.zig").server;
 const util = @import("../util.zig");
@@ -156,37 +157,37 @@ pub fn input(
     }
 
     if (mem.eql(u8, "events", args[2])) {
-        input_config.event_state = std.meta.stringToEnum(InputConfig.EventState, args[3]) orelse
+        input_config.event_state = meta.stringToEnum(InputConfig.EventState, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "accel-profile", args[2])) {
-        input_config.accel_profile = std.meta.stringToEnum(InputConfig.AccelProfile, args[3]) orelse
+        input_config.accel_profile = meta.stringToEnum(InputConfig.AccelProfile, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "click-method", args[2])) {
-        input_config.click_method = std.meta.stringToEnum(InputConfig.ClickMethod, args[3]) orelse
+        input_config.click_method = meta.stringToEnum(InputConfig.ClickMethod, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "drag", args[2])) {
-        input_config.drag_state = std.meta.stringToEnum(InputConfig.DragState, args[3]) orelse
+        input_config.drag_state = meta.stringToEnum(InputConfig.DragState, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "drag-lock", args[2])) {
-        input_config.drag_lock = std.meta.stringToEnum(InputConfig.DragLock, args[3]) orelse
+        input_config.drag_lock = meta.stringToEnum(InputConfig.DragLock, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "disable-while-typing", args[2])) {
-        input_config.dwt_state = std.meta.stringToEnum(InputConfig.DwtState, args[3]) orelse
+        input_config.dwt_state = meta.stringToEnum(InputConfig.DwtState, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "middle-emulation", args[2])) {
-        input_config.middle_emulation = std.meta.stringToEnum(InputConfig.MiddleEmulation, args[3]) orelse
+        input_config.middle_emulation = meta.stringToEnum(InputConfig.MiddleEmulation, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "natural-scroll", args[2])) {
-        input_config.natural_scroll = std.meta.stringToEnum(InputConfig.NaturalScroll, args[3]) orelse
+        input_config.natural_scroll = meta.stringToEnum(InputConfig.NaturalScroll, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "left-handed", args[2])) {
-        input_config.left_handed = std.meta.stringToEnum(InputConfig.LeftHanded, args[3]) orelse
+        input_config.left_handed = meta.stringToEnum(InputConfig.LeftHanded, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "tap", args[2])) {
-        input_config.tap_state = std.meta.stringToEnum(InputConfig.TapState, args[3]) orelse
+        input_config.tap_state = meta.stringToEnum(InputConfig.TapState, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "tap-button-map", args[2])) {
-        input_config.tap_button_map = std.meta.stringToEnum(InputConfig.TapButtonMap, args[3]) orelse
+        input_config.tap_button_map = meta.stringToEnum(InputConfig.TapButtonMap, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "pointer-accel", args[2])) {
         input_config.pointer_accel = InputConfig.PointerAccel{
@@ -197,7 +198,7 @@ pub fn input(
             ),
         };
     } else if (mem.eql(u8, "scroll-method", args[2])) {
-        input_config.scroll_method = std.meta.stringToEnum(InputConfig.ScrollMethod, args[3]) orelse
+        input_config.scroll_method = meta.stringToEnum(InputConfig.ScrollMethod, args[3]) orelse
             return Error.UnknownOption;
     } else if (mem.eql(u8, "scroll-button", args[2])) {
         const ret = c.libevdev_event_code_from_name(c.EV_KEY, args[3]);

--- a/river/command/layout.zig
+++ b/river/command/layout.zig
@@ -25,7 +25,7 @@ const Error = @import("../command.zig").Error;
 const Seat = @import("../Seat.zig");
 
 pub fn outputLayout(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -39,7 +39,7 @@ pub fn outputLayout(
 }
 
 pub fn defaultLayout(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     _: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -62,7 +62,7 @@ pub fn defaultLayout(
 /// riverctl send-layout-cmd rivertile "mod-main-factor -0.1"
 /// riverctl send-layout-cmd rivertile "main-location top"
 pub fn sendLayoutCmd(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,

--- a/river/command/move.zig
+++ b/river/command/move.zig
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const math = std.math;
 
 const server = &@import("../main.zig").server;
 
@@ -100,11 +101,11 @@ pub fn resize(
             } else {
                 // Prevent underflow
                 view.pending.box.width -=
-                    std.math.min(view.pending.box.width, @intCast(u32, -1 * delta));
+                    math.min(view.pending.box.width, @intCast(u32, -1 * delta));
             }
             view.applyConstraints();
             // Do not grow bigger than the output
-            view.pending.box.width = std.math.min(
+            view.pending.box.width = math.min(
                 view.pending.box.width,
                 output_box.width - @intCast(u32, 2 * border_width),
             );
@@ -118,11 +119,11 @@ pub fn resize(
             } else {
                 // Prevent underflow
                 view.pending.box.height -=
-                    std.math.min(view.pending.box.height, @intCast(u32, -1 * delta));
+                    math.min(view.pending.box.height, @intCast(u32, -1 * delta));
             }
             view.applyConstraints();
             // Do not grow bigger than the output
-            view.pending.box.height = std.math.min(
+            view.pending.box.height = math.min(
                 view.pending.box.height,
                 output_box.height - @intCast(u32, 2 * border_width),
             );

--- a/river/command/output.zig
+++ b/river/command/output.zig
@@ -15,6 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const assert = std.debug.assert;
+const mem = std.mem;
 
 const wlr = @import("wlroots");
 
@@ -27,7 +29,7 @@ const Output = @import("../Output.zig");
 const Seat = @import("../Seat.zig");
 
 pub fn focusOutput(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -37,7 +39,7 @@ pub fn focusOutput(
 
     // If the noop output is focused, there are no other outputs to switch to
     if (seat.focused_output == &server.root.noop_output) {
-        std.debug.assert(server.root.outputs.len == 0);
+        assert(server.root.outputs.len == 0);
         return;
     }
 
@@ -47,7 +49,7 @@ pub fn focusOutput(
 }
 
 pub fn sendToOutput(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     _: *?[]const u8,
@@ -57,7 +59,7 @@ pub fn sendToOutput(
 
     // If the noop output is focused, there is nowhere to send the view
     if (seat.focused_output == &server.root.noop_output) {
-        std.debug.assert(server.root.outputs.len == 0);
+        assert(server.root.outputs.len == 0);
         return;
     }
 
@@ -98,7 +100,7 @@ fn getOutput(seat: *Seat, str: []const u8) !?*Output {
         // Check if an output matches by name
         var it = server.root.outputs.first;
         while (it) |node| : (it = node.next) {
-            if (std.mem.eql(u8, std.mem.span(node.data.wlr_output.name), str)) {
+            if (mem.eql(u8, mem.span(node.data.wlr_output.name), str)) {
                 return &node.data;
             }
         }

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
+const mem = std.mem;
 
 const server = &@import("../main.zig").server;
 
@@ -23,7 +24,7 @@ const Seat = @import("../Seat.zig");
 
 /// Switch focus to the passed tags.
 pub fn setFocusedTags(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
@@ -40,7 +41,7 @@ pub fn setFocusedTags(
 
 /// Set the spawn tagmask
 pub fn spawnTagmask(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
@@ -51,7 +52,7 @@ pub fn spawnTagmask(
 
 /// Set the tags of the focused view.
 pub fn setViewTags(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
@@ -67,7 +68,7 @@ pub fn setViewTags(
 
 /// Toggle focus of the passsed tags.
 pub fn toggleFocusedTags(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
@@ -86,7 +87,7 @@ pub fn toggleFocusedTags(
 
 /// Toggle the passed tags of the focused view
 pub fn toggleViewTags(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     seat: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
@@ -105,7 +106,7 @@ pub fn toggleViewTags(
 
 /// Switch focus to tags that were selected previously
 pub fn focusPreviousTags(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const []const u8,
     _: *?[]const u8,
@@ -123,7 +124,7 @@ pub fn focusPreviousTags(
 
 /// Set the tags of the focused view to the tags that were selected previously
 pub fn sendToPreviousTags(
-    _: std.mem.Allocator,
+    _: mem.Allocator,
     seat: *Seat,
     args: []const []const u8,
     _: *?[]const u8,
@@ -139,7 +140,7 @@ pub fn sendToPreviousTags(
 }
 
 fn parseTags(
-    allocator: std.mem.Allocator,
+    allocator: mem.Allocator,
     args: []const [:0]const u8,
     out: *?[]const u8,
 ) Error!u32 {

--- a/river/main.zig
+++ b/river/main.zig
@@ -167,7 +167,7 @@ pub fn log(
 
     const scope_prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
 
-    const stderr = std.io.getStdErr().writer();
+    const stderr = io.getStdErr().writer();
     stderr.print(level.asText() ++ scope_prefix ++ format ++ "\n", args) catch {};
 }
 

--- a/river/render.zig
+++ b/river/render.zig
@@ -16,7 +16,6 @@
 
 const build_options = @import("build_options");
 const std = @import("std");
-const mem = std.mem;
 const os = std.os;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;

--- a/river/util.zig
+++ b/river/util.zig
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 const std = @import("std");
-const os = std.os;
 
 /// The global general-purpose allocator used throughout river's code
 pub const gpa = std.heap.c_allocator;

--- a/riverctl/main.zig
+++ b/riverctl/main.zig
@@ -119,7 +119,7 @@ fn callbackListener(_: *zriver.CommandCallbackV1, event: zriver.CommandCallbackV
     switch (event) {
         .success => |success| {
             if (mem.len(success.output) > 0) {
-                const stdout = std.io.getStdOut().writer();
+                const stdout = io.getStdOut().writer();
                 stdout.print("{s}\n", .{success.output}) catch @panic("failed to write to stdout");
             }
             os.exit(0);
@@ -138,5 +138,5 @@ fn callbackListener(_: *zriver.CommandCallbackV1, event: zriver.CommandCallbackV
 
 fn fatal(comptime format: []const u8, args: anytype) noreturn {
     std.log.err(format, args);
-    std.os.exit(1);
+    os.exit(1);
 }

--- a/rivertile/main.zig
+++ b/rivertile/main.zig
@@ -36,6 +36,7 @@
 // +-----------------------+------------+
 
 const std = @import("std");
+const fmt = std.fmt;
 const mem = std.mem;
 const math = std.math;
 const os = std.os;
@@ -164,7 +165,7 @@ const Output = struct {
                         };
                     },
                     .@"main-count" => {
-                        const arg = std.fmt.parseInt(i32, raw_arg, 10) catch |err| {
+                        const arg = fmt.parseInt(i32, raw_arg, 10) catch |err| {
                             std.log.err("failed to parse argument: {}", .{err});
                             return;
                         };
@@ -178,7 +179,7 @@ const Output = struct {
                         }
                     },
                     .@"main-ratio" => {
-                        const arg = std.fmt.parseFloat(f64, raw_arg) catch |err| {
+                        const arg = fmt.parseFloat(f64, raw_arg) catch |err| {
                             std.log.err("failed to parse argument: {}", .{err});
                             return;
                         };
@@ -331,11 +332,11 @@ pub fn main() !void {
         os.exit(0);
     }
     if (result.argFlag("-view-padding")) |raw| {
-        view_padding = std.fmt.parseUnsigned(u32, raw, 10) catch
+        view_padding = fmt.parseUnsigned(u32, raw, 10) catch
             fatalPrintUsage("invalid value '{s}' provided to -view-padding", .{raw});
     }
     if (result.argFlag("-outer-padding")) |raw| {
-        outer_padding = std.fmt.parseUnsigned(u32, raw, 10) catch
+        outer_padding = fmt.parseUnsigned(u32, raw, 10) catch
             fatalPrintUsage("invalid value '{s}' provided to -outer-padding", .{raw});
     }
     if (result.argFlag("-main-location")) |raw| {
@@ -343,11 +344,11 @@ pub fn main() !void {
             fatalPrintUsage("invalid value '{s}' provided to -main-location", .{raw});
     }
     if (result.argFlag("-main-count")) |raw| {
-        default_main_count = std.fmt.parseUnsigned(u32, raw, 10) catch
+        default_main_count = fmt.parseUnsigned(u32, raw, 10) catch
             fatalPrintUsage("invalid value '{s}' provided to -main-count", .{raw});
     }
     if (result.argFlag("-main-ratio")) |raw| {
-        default_main_ratio = std.fmt.parseFloat(f64, raw) catch
+        default_main_ratio = fmt.parseFloat(f64, raw) catch
             fatalPrintUsage("invalid value '{s}' provided to -main-ratio", .{raw});
     }
 


### PR DESCRIPTION
So I come accross some case where there was in the same file for example `std.mem.foo()` but also `const mem = std.mem;` at the beginning of the file, so I tried to cleanup a bit everything, either adding `const foo = std.foo` if the lib was called a lot of time or just fix when both `std.foo` and `foo()` were used.

Sorry for the not so great commit message, I didn't know how to describe this tbh.