### PR TITLE
river-man-page: change log level warn to warning

### DIFF
--- a/doc/river.1.scd
+++ b/doc/river.1.scd
@@ -31,7 +31,7 @@ utility may be used to communicate with river over these protocols.
 	_shell_command_ will be run with _/bin/sh -c_. See the *CONFIGURATION*
 	section for more details.
 
-*-log-level* [*error*|*warn*|*info*|*debug*]
+*-log-level* [*error*|*warning*|*info*|*debug*]
 	Set the log level of river. At the *error* log level, only errors
 	are logged.  At the *debug* log level, everything is logged including
 	verbose debug messages.


### PR DESCRIPTION
The river man page lists the log levels as "error|warn|info|debug", but level "warn" doesn't exist. The correct level, as `river --help` shows, is "warning".

I bypassed setting up an issue since this is basically a typo. If this was a bad idea, I sincerely apologize.