### PR TITLE
Add command to hide cursor while typing or after a timeout

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -288,6 +288,15 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	If the view to be focused is on an output that does not have focus,
 	focus is switched to that output.
 
+*hide-cursor* *timeout* _timeout_
+	Hide the cursor if it wasn't moved in the last _timeout_ milliseconds
+	until it is moved again. The default value is 0, which disables
+	automatically hiding the cursor. Show the cursor again on any movement.
+
+*hide-cursor* *when-typing* *enabled*|*disabled*
+	Hide the cursor when pressing any non-modifier key. Show the cursor
+	again on any movement.
+
 *set-cursor-warp* *disabled*|*on-output-change*
 	Set the cursor warp mode. There are two available modes:
 

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -36,6 +36,11 @@ pub const WarpCursorMode = enum {
     @"on-output-change",
 };
 
+pub const HideCursorWhenTypingMode = enum {
+    disabled,
+    enabled,
+};
+
 /// Color of background in RGBA (alpha should only affect nested sessions)
 background_color: [4]f32 = [_]f32{ 0.0, 0.16862745, 0.21176471, 1.0 }, // Solarized base03
 
@@ -84,6 +89,12 @@ repeat_rate: u31 = 25,
 
 /// Keyboard repeat delay in milliseconds
 repeat_delay: u31 = 600,
+
+/// Cursor hide timeout in milliseconds
+cursor_hide_timeout: u31 = 0,
+
+/// Hide the cursor while typing
+cursor_hide_when_typing: HideCursorWhenTypingMode = .disabled,
 
 pub fn init() !Self {
     var self = Self{

--- a/river/command.zig
+++ b/river/command.zig
@@ -59,6 +59,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "focus-output",              @import("command/output.zig").focusOutput },
         .{ "focus-previous-tags",       @import("command/tags.zig").focusPreviousTags },
         .{ "focus-view",                @import("command/focus_view.zig").focusView },
+        .{ "hide-cursor",               @import("command/cursor.zig").cursor },
         .{ "input",                     @import("command/input.zig").input },
         .{ "list-input-configs",        @import("command/input.zig").listInputConfigs},
         .{ "list-inputs",               @import("command/input.zig").listInputs },

--- a/river/command/cursor.zig
+++ b/river/command/cursor.zig
@@ -1,0 +1,50 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2022 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const util = @import("../util.zig");
+
+const server = &@import("../main.zig").server;
+
+const Config = @import("../Config.zig");
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+
+pub fn cursor(
+    _: *Seat,
+    args: []const [:0]const u8,
+    _: *?[]const u8,
+) Error!void {
+    if (std.mem.eql(u8, "timeout", args[1])) {
+        if (args.len < 3) return Error.NotEnoughArguments;
+        if (args.len > 3) return Error.TooManyArguments;
+        server.config.cursor_hide_timeout = try std.fmt.parseInt(u31, args[2], 10);
+        var seat_it = server.input_manager.seats.first;
+        while (seat_it) |seat_node| : (seat_it = seat_node.next) {
+            const seat = &seat_node.data;
+            seat.cursor.unhide();
+        }
+    } else if (std.mem.eql(u8, "when-typing", args[1])) {
+        if (args.len < 3) return Error.NotEnoughArguments;
+        if (args.len > 3) return Error.TooManyArguments;
+        server.config.cursor_hide_when_typing = std.meta.stringToEnum(Config.HideCursorWhenTypingMode, args[2]) orelse
+            return Error.UnknownOption;
+    } else {
+        return Error.UnknownOption;
+    }
+}


### PR DESCRIPTION
From the riverctl.1:

```
*hide-cursor* *timeout* _timeout_
	Hide the cursor if it wasn't moved in the last _timeout_ milliseconds, until
	it is moved again.
	The default value is 0, which disables automatically hiding the cursor.

*hide-cursor* *jitter* _hide_delta_ _unhide_delta_
	- _hide_delta_: How many logical pixels the cursor has to move to reset the
	  hide timeout.
	- _unhide_delta_: How many logical pixels the cursor has to move to show the
	  cursor again.
	The default value is for both is 0, which disables the jitter.

*hide-cursor* *jitter* _delta_
	Sets both *hide-cursor* *jitter* _hide_delta_ and _unhide_delta_ to _delta_.

*hide-cursor* *when-typing* *enabled*|*disabled*
	Hide the cursor when typing starts, the cursor has to move to be shown again.
```