### PR TITLE
view: stop enforcing custom minimum size

### DIFF
--- a/river/Root.zig
+++ b/river/Root.zig
@@ -31,14 +31,6 @@ const ViewStack = @import("view_stack.zig").ViewStack;
 const XwaylandUnmanaged = @import("XwaylandUnmanaged.zig");
 const DragIcon = @import("DragIcon.zig");
 
-// Minimum effective width/height for outputs.
-// This is needed, to prevent integer overflows caused by the output effective
-// resolution beeing too small to fit clients that can't get scaled more and
-// thus will be bigger than the output resolution.
-// The value is totally arbitrary and low enough, that it should never be
-// encountered during normal usage.
-const min_size = 50;
-
 new_output: wl.Listener(*wlr.Output) = wl.Listener(*wlr.Output).init(handleNewOutput),
 
 output_layout: *wlr.OutputLayout,

--- a/river/View.zig
+++ b/river/View.zig
@@ -43,14 +43,6 @@ pub const Constraints = struct {
     max_height: u32,
 };
 
-// Minimum width/height for surfaces.
-// This is needed, because external layouts and large padding and border sizes
-// may cause surfaces so small, that bugs in client applications are encountered,
-// or even surfaces of zero or negative size,which are a protocol error and would
-// likely cause river to crash. The value is totally arbitrary and low enough,
-// that it should never be encountered during normal usage.
-pub const min_size = 50;
-
 const Impl = union(enum) {
     xdg_toplevel: XdgToplevel,
     xwayland_view: XwaylandView,

--- a/river/XdgToplevel.zig
+++ b/river/XdgToplevel.zig
@@ -143,9 +143,9 @@ pub fn getAppId(self: Self) ?[*:0]const u8 {
 pub fn getConstraints(self: Self) View.Constraints {
     const state = &self.xdg_surface.role_data.toplevel.current;
     return .{
-        .min_width = math.max(state.min_width, View.min_size),
+        .min_width = math.max(state.min_width, 1),
         .max_width = if (state.max_width > 0) state.max_width else math.maxInt(u32),
-        .min_height = math.max(state.min_height, View.min_size),
+        .min_height = math.max(state.min_height, 1),
         .max_height = if (state.max_height > 0) state.max_height else math.maxInt(u32),
     };
 }

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -141,22 +141,22 @@ pub fn getAppId(self: Self) ?[*:0]const u8 {
 /// Return bounds on the dimensions of the view
 pub fn getConstraints(self: Self) View.Constraints {
     const hints = self.xwayland_surface.size_hints orelse return .{
-        .min_width = View.min_size,
-        .min_height = View.min_size,
+        .min_width = 1,
+        .min_height = 1,
         .max_width = math.maxInt(u32),
         .max_height = math.maxInt(u32),
     };
     return .{
-        .min_width = @intCast(u32, math.max(hints.min_width, View.min_size)),
-        .min_height = @intCast(u32, math.max(hints.min_height, View.min_size)),
+        .min_width = @intCast(u32, math.max(hints.min_width, 1)),
+        .min_height = @intCast(u32, math.max(hints.min_height, 1)),
 
         .max_width = if (hints.max_width > 0)
-            math.max(@intCast(u32, hints.max_width), View.min_size)
+            @intCast(u32, hints.max_width)
         else
             math.maxInt(u32),
 
         .max_height = if (hints.max_height > 0)
-            math.max(@intCast(u32, hints.max_height), View.min_size)
+            @intCast(u32, hints.max_height)
         else
             math.maxInt(u32),
     };


### PR DESCRIPTION
I have encountered a crash (failing assert) if a view specified a fixed
size less than this minimum, and according to ifreund this behavior was
planned to be removed, anyway.