### PR TITLE
layout-independent mappings

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -56,7 +56,7 @@ function __riverctl_completion ()
 			"focus-output"|"focus-view"|"send-to-output"|"swap") OPTS="next previous" ;;
 			"move"|"snap") OPTS="up down left right" ;;
 			"resize") OPTS="horizontal vertical" ;;
-			"map") OPTS="-release -repeat" ;;
+			"map") OPTS="-release -repeat -layout" ;;
 			"unmap") OPTS="-release" ;;
 			"attach-mode") OPTS="top bottom" ;;
 			"focus-follows-cursor") OPTS="disabled normal" ;;

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -70,7 +70,7 @@ complete -c riverctl -x -n '__fish_seen_subcommand_from resize'               -a
 complete -c riverctl -x -n '__fish_seen_subcommand_from snap'                 -a 'up down left right'
 complete -c riverctl -x -n '__fish_seen_subcommand_from send-to-output'       -a 'next previous'
 complete -c riverctl -x -n '__fish_seen_subcommand_from swap'                 -a 'next previous'
-complete -c riverctl -x -n '__fish_seen_subcommand_from map'                  -a '-release -repeat'
+complete -c riverctl -x -n '__fish_seen_subcommand_from map'                  -a '-release -repeat -layout'
 complete -c riverctl -x -n '__fish_seen_subcommand_from unmap'                -a '-release'
 complete -c riverctl -x -n '__fish_seen_subcommand_from attach-mode'          -a 'top bottom'
 complete -c riverctl -x -n '__fish_seen_subcommand_from focus-follows-cursor' -a 'disabled normal'

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -169,7 +169,7 @@ _riverctl()
                 snap) _alternative 'arguments:args:(up down left right)' ;;
                 send-to-output) _alternative 'arguments:args:(next previous)' ;;
                 swap) _alternative 'arguments:args:(next previous)' ;;
-                map) _alternative 'arguments:optional:(-release -repeat)' ;;
+                map) _alternative 'arguments:optional:(-release -repeat -layout)' ;;
                 unmap) _alternative 'arguments:optional:(-release)' ;;
                 attach-mode) _alternative 'arguments:args:(top bottom)' ;;
                 focus-follows-cursor) _alternative 'arguments:args:(disabled normal)' ;;

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -193,13 +193,19 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 *enter-mode* _name_
 	Switch to given mode if it exists.
 
-*map* [_-release_|_-repeat_] _mode_ _modifiers_ _key_ _command_
+*map* [_-release_|_-repeat_|_-layout_ _index_] _mode_ _modifiers_ _key_ _command_
 	Run _command_ when _key_ is pressed while _modifiers_ are held down
 	and in the specified _mode_.
 
 	- _-release_: if passed activate on key release instead of key press
 	- _-repeat_: if passed activate repeatedly until key release; may not
 	  be used with -release
+	- _-layout_: if passed, a specific layout is pinned to the mapping.
+	  When the mapping is checked against a pressed key, this layout is
+	  used to translate the key independent of the active layout
+	- _index_: zero-based index of a layout set with the environment variable
+	  *XKB_DEFAULT_LAYOUT*; see *river*(1) for an example; if the index is
+	  out of range, the _-layout_ option will have no effect
 	- _mode_: name of the mode for which to create the mapping
 	- _modifiers_: one or more of the modifiers listed above, separated
 	  by a plus sign (+).


### PR DESCRIPTION
After some discussions, we came to the conclusion, that layout-independent mappings are best achieved with the ability to pin a certain layout to a mapping.

E.g. something like `riverctl map -layout "French" normal Super Y spawn foot`.

When this mapping is checked, the specified layout will be used to translate the received key instead of the currently active layout.

The details are yet to be decided.