### PR TITLE
Cursor: add on-focus-change option 

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -64,7 +64,7 @@ function __riverctl_completion ()
 			"unmap") OPTS="-release" ;;
 			"attach-mode") OPTS="top bottom" ;;
 			"focus-follows-cursor") OPTS="disabled normal always" ;;
-			"set-cursor-warp") OPTS="disabled on-output-change" ;;
+			"set-cursor-warp") OPTS="disabled on-output-change on-focus-change" ;;
 			"hide-cursor") OPTS="timeout when-typing" ;;
 			*) return ;;
 		esac

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -79,7 +79,7 @@ complete -c riverctl -x -n '__fish_seen_subcommand_from map'                  -a
 complete -c riverctl -x -n '__fish_seen_subcommand_from unmap'                -a '-release'
 complete -c riverctl -x -n '__fish_seen_subcommand_from attach-mode'          -a 'top bottom'
 complete -c riverctl -x -n '__fish_seen_subcommand_from focus-follows-cursor' -a 'disabled normal always'
-complete -c riverctl -x -n '__fish_seen_subcommand_from set-cursor-warp'      -a 'disabled on-output-change'
+complete -c riverctl -x -n '__fish_seen_subcommand_from set-cursor-warp'      -a 'disabled on-output-change on-focus-change'
 
 # Subcommands for 'input'
 complete -c riverctl -x -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 2' -a "(__riverctl_list_input_devices)"

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -178,7 +178,7 @@ _riverctl()
                 unmap) _alternative 'arguments:optional:(-release)' ;;
                 attach-mode) _alternative 'arguments:args:(top bottom)' ;;
                 focus-follows-cursor) _alternative 'arguments:args:(disabled normal always)' ;;
-                set-cursor-warp) _alternative 'arguments:args:(disabled on-output-change)' ;;
+                set-cursor-warp) _alternative 'arguments:args:(disabled on-output-change on-focus-change)' ;;
                 hide-cursor) _riverctl_hide_cursor ;;
                 *) return 0 ;;
             esac

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -307,11 +307,13 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	Hide the cursor when pressing any non-modifier key. Show the cursor
 	again on any movement.
 
-*set-cursor-warp* *disabled*|*on-output-change*
+*set-cursor-warp* *disabled*|*on-output-change*|*on-focus-change*
 	Set the cursor warp mode. There are two available modes:
 
 	- _disabled_: Cursor will not be warped. This is the default.
 	- _on-output-change_: When a different output is focused, the cursor will be
+	  warped to its center.
+	- _on-focus-change_: When a different view/output is focused, the cursor will be
 	  warped to its center.
 
 *set-repeat* _rate_ _delay_

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -36,6 +36,7 @@ pub const FocusFollowsCursorMode = enum {
 pub const WarpCursorMode = enum {
     disabled,
     @"on-output-change",
+    @"on-focus-change",
 };
 
 pub const HideCursorWhenTypingMode = enum {

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -265,6 +265,10 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
             PointerConstraint.warpToHint(&self.cursor);
             constraint.sendDeactivated();
             self.cursor.constraint = null;
+        } else {
+            // Depending on configuration and cursor position, changing keyboard focus
+            // may cause the cursor to be warped.
+            self.cursor.may_need_warp = true;
         }
     } else {
         self.wlr_seat.keyboardClearFocus();
@@ -273,6 +277,10 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
             PointerConstraint.warpToHint(&self.cursor);
             constraint.sendDeactivated();
             self.cursor.constraint = null;
+        } else {
+            // Depending on configuration and cursor position, changing keyboard focus
+            // may cause the cursor to be warped.
+            self.cursor.may_need_warp = true;
         }
     }
 
@@ -313,28 +321,6 @@ pub fn focusOutput(self: *Self, output: *Output) void {
 
     it = self.status_trackers.first;
     while (it) |node| : (it = node.next) node.data.sendOutput(.focused);
-
-    if (self.focused_output == &server.root.noop_output) return;
-
-    // Warp pointer to center of newly focused output (In layout coordinates),
-    // but only if cursor is not already on the output and this feature is enabled.
-    switch (server.config.warp_cursor) {
-        .disabled => {},
-        .@"on-output-change" => {
-            var layout_box: wlr.Box = undefined;
-            server.root.output_layout.getBox(output.wlr_output, &layout_box);
-            if (!layout_box.containsPoint(self.cursor.wlr_cursor.x, self.cursor.wlr_cursor.y)) {
-                var output_width: i32 = undefined;
-                var output_height: i32 = undefined;
-                output.wlr_output.effectiveResolution(&output_width, &output_height);
-                const lx = @intToFloat(f64, layout_box.x + @divTrunc(output_width, 2));
-                const ly = @intToFloat(f64, layout_box.y + @divTrunc(output_height, 2));
-                if (!self.cursor.wlr_cursor.warp(null, lx, ly)) {
-                    log.err("failed to warp cursor on output change", .{});
-                }
-            }
-        },
-    }
 }
 
 pub fn handleActivity(self: Self) void {


### PR DESCRIPTION
Warp the cursor to the center of the focused view if it is not in the bounding box of that view.

This helps the user to keep track of their cursor when they mostly use the keyboard and the cursor becomes hidden most of the time, also helps trackpad/trackpoint users.