### PR TITLE
Shell completions for 'hide-cursor' riverctl command

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -45,6 +45,7 @@ function __riverctl_completion ()
 			border-color-urgent \
 			border-width \
 			focus-follows-cursor \
+			hide-cursor \
 			set-repeat \
 			set-cursor-warp \
 			xcursor-theme"
@@ -60,6 +61,7 @@ function __riverctl_completion ()
 			"attach-mode") OPTS="top bottom" ;;
 			"focus-follows-cursor") OPTS="disabled normal" ;;
 			"set-cursor-warp") OPTS="disabled on-output-change" ;;
+			"hide-cursor") OPTS="timeout when-typing" ;;
 			*) return ;;
 		esac
 		COMPREPLY=($(compgen -W "${OPTS}" -- "${COMP_WORDS[2]}"))
@@ -82,6 +84,13 @@ function __riverctl_completion ()
 				scroll-method \
 				scroll-button"
 			COMPREPLY=($(compgen -W "${OPTS}" -- "${COMP_WORDS[2]}"))
+		elif [ "${COMP_WORDS[1]}" == "hide-cursor" ]
+		then
+			case "${COMP_WORDS[2]}" in
+				"when-typing") OPTS="enabled disabled" ;;
+				*) return ;;
+			esac
+			COMPREPLY=($(compgen -W "${OPTS}" -- "${COMP_WORDS[3]}"))
 		fi
 	elif [ "${COMP_CWORD}" -eq 4 ]
 	then

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -57,6 +57,7 @@ complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'border-color-unf
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'border-color-urgent'    -d 'Set the border color of urgent views'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'border-width'           -d 'Set the border width to pixels'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'focus-follows-cursor'   -d 'Configure the focus behavior when moving cursor'
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'hide-cursor'            -d 'Hide cursor when typing or after inactivity'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'set-repeat'             -d 'Set the keyboard repeat rate and repeat delay'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'set-cursor-warp'        -d 'Set the cursor warp mode.'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'xcursor-theme'          -d 'Set the xcursor theme'
@@ -102,3 +103,10 @@ complete -c riverctl -x -n '__fish_seen_subcommand_from input; and __fish_riverc
 complete -c riverctl -x -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 4; and __fish_seen_subcommand_from scroll-method'  -a 'two-finger' -d 'Scroll by swiping with two fingers simultaneously'
 complete -c riverctl -x -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 4; and __fish_seen_subcommand_from scroll-method'  -a 'edge'       -d 'Scroll by swiping along the edge'
 complete -c riverctl -x -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 4; and __fish_seen_subcommand_from scroll-method'  -a 'button'     -d 'Scroll with pointer movement while holding down a button'
+
+# Subcommands for 'hide-cursor'
+complete -c riverctl -x -n '__fish_seen_subcommand_from hide-cursor; and __fish_riverctl_complete_arg 2' -a 'timeout'     -d 'Hide cursor if it wasn\'t moved in the last X millisecond, until it is moved again'
+complete -c riverctl -x -n '__fish_seen_subcommand_from hide-cursor; and __fish_riverctl_complete_arg 2' -a 'when-typing' -d 'Enable or disable whether the cursor should be hidden when pressing any non-modifier key'
+
+# Subcommands for the subcommands of ‘hide-cursor’
+complete -c riverctl -x -n '__fish_seen_subcommand_from hide-cursor; and __fish_riverctl_complete_arg 3; and __fish_seen_subcommand_from when-typing' -a 'enabled disabled'

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -51,6 +51,7 @@ _riverctl_subcommands()
         'border-color-urgent:Set the border color of urgent views'
         'border-width:Set the border width to pixels'
         'focus-follows-cursor:Configure the focus behavior when moving cursor'
+        'hide-cursor:Hide cursor when typing or after inactivity'
         'set-repeat:Set the keyboard repeat rate and repeat delay'
         'set-cursor-warp:Set the cursor warp mode.'
         'xcursor-theme:Set the xcursor theme'
@@ -117,6 +118,37 @@ _riverctl_input()
     esac
 }
 
+_riverctl_hide_cursor_subcommands()
+{
+    local -a hide_cursor_subcommands
+
+    hide_cursor_subcommands=(
+        "timeout:Hide cursor if it wasn\'t moved in the last X millisecond, until it is moved again"
+        'when-typing:Enable or disable whether the cursor should be hidden when pressing any non-modifier key'
+    )
+
+    _describe -t command 'command' hide_cursor_subcommands
+}
+
+_riverctl_hide_cursor()
+{
+    local state
+
+    _arguments \
+        '1: :->commands' \
+        '*:: :->args'
+
+    case $state in
+        commands) _alternative 'common-commands:common:_riverctl_hide_cursor_subcommands' ;;
+        args)
+            case "$words[1]" in
+                when-typing) _alternative 'hide-cursor-cmds:args:(enabled disabled)' ;;
+                *) return 0 ;;
+            esac
+        ;;
+    esac
+}
+
 _riverctl()
 {
     local state
@@ -142,6 +174,7 @@ _riverctl()
                 attach-mode) _alternative 'arguments:args:(top bottom)' ;;
                 focus-follows-cursor) _alternative 'arguments:args:(disabled normal)' ;;
                 set-cursor-warp) _alternative 'arguments:args:(disabled on-output-change)' ;;
+                hide-cursor) _riverctl_hide_cursor ;;
                 *) return 0 ;;
             esac
         ;;


### PR DESCRIPTION
Add shell completions (for bash/zsh/fish) for the `hide-cursor` command.