### PR TITLE
xwayland-unmanaged: handle focus on map/cursor button

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -579,7 +579,7 @@ pub fn surfaceAt(self: Self) ?SurfaceAtResult {
     if (layerSurfaceAt(output.getLayer(.overlay).*, ox, oy)) |s| return s;
 
     if (fullscreen_view) |view| {
-        if (build_options.xwayland) if (xwaylandUnmanagedSurfaceAt(ly, lx)) |s| return s;
+        if (build_options.xwayland) if (xwaylandUnmanagedSurfaceAt(lx, ly)) |s| return s;
         var sx: f64 = undefined;
         var sy: f64 = undefined;
         if (view.surfaceAt(ox, oy, &sx, &sy)) |found| {

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -315,7 +315,13 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
                     self.seat.focus(null);
                 }
             },
-            .xwayland_unmanaged => assert(build_options.xwayland),
+            .xwayland_unmanaged => |xwayland_unmanaged| {
+                if (build_options.xwayland) {
+                    self.seat.setFocusRaw(.{ .xwayland_unmanaged = xwayland_unmanaged });
+                } else {
+                    unreachable;
+                }
+            },
         }
         _ = self.seat.wlr_seat.pointerNotifyButton(event.time_msec, event.button, event.state);
 


### PR DESCRIPTION
This should resolve https://github.com/riverwm/river/issues/455 by adding keyboard focus on map for unmanaged Xwayland views that want it (based on the relevant TODO, using wlroot's heuristic). It also adds keyboard focus when clicking on an unmanaged Xwayland view, for some consistency with layer surfaces. This was initially based on the closed PR https://github.com/riverwm/river/pull/569.

I have tested this with dmenu, as in the linked issue, and polybar (at top and bottom of screen), and it works on my end. However, there is a problem: I am unable to select an unmanaged Xwayland surface if I have another view in fullscreen. This appears to be an issue with `surfaceAt()` failing in `xwaylandUnmanagedSurfaceAt()` when in fullscreen, but I am not sure.