### PR TITLE
Xwayland: add handling of override redirect listeners

### DIFF
--- a/river/XwaylandUnmanaged.zig
+++ b/river/XwaylandUnmanaged.zig
@@ -60,6 +60,7 @@ pub fn create(xwayland_surface: *wlr.XwaylandSurface) error{OutOfMemory}!*Self {
     xwayland_surface.events.destroy.add(&self.destroy);
     xwayland_surface.events.map.add(&self.map);
     xwayland_surface.events.unmap.add(&self.unmap);
+    xwayland_surface.events.set_override_redirect.add(&self.set_override_redirect);
 
     return self;
 }
@@ -80,6 +81,7 @@ fn handleDestroy(listener: *wl.Listener(*wlr.XwaylandSurface), _: *wlr.XwaylandS
     self.destroy.link.remove();
     self.map.link.remove();
     self.unmap.link.remove();
+    self.set_override_redirect.link.remove();
 
     // Deallocate the node
     const node = @fieldParentPtr(std.TailQueue(Self).Node, "data", self);

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -83,6 +83,7 @@ pub fn create(output: *Output, xwayland_surface: *wlr.XwaylandSurface) error{Out
     xwayland_surface.events.map.add(&self.map);
     xwayland_surface.events.unmap.add(&self.unmap);
     xwayland_surface.events.request_configure.add(&self.request_configure);
+    xwayland_surface.events.set_override_redirect.add(&self.set_override_redirect);
 
     return self;
 }
@@ -188,6 +189,7 @@ fn handleDestroy(listener: *wl.Listener(*wlr.XwaylandSurface), _: *wlr.XwaylandS
     self.map.link.remove();
     self.unmap.link.remove();
     self.request_configure.link.remove();
+    self.set_override_redirect.link.remove();
 
     self.view.destroy();
 }


### PR DESCRIPTION
Handling of the `set_override_redirect` listener in `create()` and `handleDestroy()` was missed in https://github.com/riverwm/river/commit/6ef97eea241ecc5bec32e0cf820c3644692f5554, so Xwayland views don't actually switch between being managed and unmanaged.