### PR TITLE
 Fix the mod key issues with the default init script

### DIFF
--- a/example/init
+++ b/example/init
@@ -8,113 +8,116 @@
 # See the river(1), riverctl(1), and rivertile(1) man pages for complete
 # documentation.
 
-# Note: the "Super" modifier is also known as Logo, GUI, Windows, Mod4, etc.
+Super="Mod4"
+Alt="Mod1"
 
-# Super+Shift+Return to start an instance of foot (https://codeberg.org/dnkl/foot)
-riverctl map normal Super+Shift Return spawn foot
+# Note: the "$Super" modifier is also known as Logo, GUI, Windows, Mod4, etc.
 
-# Super+Q to close the focused view
-riverctl map normal Super Q close
+# $Super+Shift+Return to start an instance of foot (https://codeberg.org/dnkl/foot)
+riverctl map normal $Super+Shift Return spawn foot
 
-# Super+Shift+E to exit river
-riverctl map normal Super+Shift E exit
+# $Super+Q to close the focused view
+riverctl map normal $Super Q close
 
-# Super+J and Super+K to focus the next/previous view in the layout stack
-riverctl map normal Super J focus-view next
-riverctl map normal Super K focus-view previous
+# $Super+Shift+E to exit river
+riverctl map normal $Super+Shift E exit
 
-# Super+Shift+J and Super+Shift+K to swap the focused view with the next/previous
+# $Super+J and $Super+K to focus the next/previous view in the layout stack
+riverctl map normal $Super J focus-view next
+riverctl map normal $Super K focus-view previous
+
+# $Super+Shift+J and $Super+Shift+K to swap the focused view with the next/previous
 # view in the layout stack
-riverctl map normal Super+Shift J swap next
-riverctl map normal Super+Shift K swap previous
+riverctl map normal $Super+Shift J swap next
+riverctl map normal $Super+Shift K swap previous
 
-# Super+Period and Super+Comma to focus the next/previous output
-riverctl map normal Super Period focus-output next
-riverctl map normal Super Comma focus-output previous
+# $Super+Period and $Super+Comma to focus the next/previous output
+riverctl map normal $Super Period focus-output next
+riverctl map normal $Super Comma focus-output previous
 
-# Super+Shift+{Period,Comma} to send the focused view to the next/previous output
-riverctl map normal Super+Shift Period send-to-output next
-riverctl map normal Super+Shift Comma send-to-output previous
+# $Super+Shift+{Period,Comma} to send the focused view to the next/previous output
+riverctl map normal $Super+Shift Period send-to-output next
+riverctl map normal $Super+Shift Comma send-to-output previous
 
-# Super+Return to bump the focused view to the top of the layout stack
-riverctl map normal Super Return zoom
+# $Super+Return to bump the focused view to the top of the layout stack
+riverctl map normal $Super Return zoom
 
-# Super+H and Super+L to decrease/increase the main ratio of rivertile(1)
-riverctl map normal Super H send-layout-cmd rivertile "main-ratio -0.05"
-riverctl map normal Super L send-layout-cmd rivertile "main-ratio +0.05"
+# $Super+H and $Super+L to decrease/increase the main ratio of rivertile(1)
+riverctl map normal $Super H send-layout-cmd rivertile "main-ratio -0.05"
+riverctl map normal $Super L send-layout-cmd rivertile "main-ratio +0.05"
 
-# Super+Shift+H and Super+Shift+L to increment/decrement the main count of rivertile(1)
-riverctl map normal Super+Shift H send-layout-cmd rivertile "main-count +1"
-riverctl map normal Super+Shift L send-layout-cmd rivertile "main-count -1"
+# $Super+Shift+H and $Super+Shift+L to increment/decrement the main count of rivertile(1)
+riverctl map normal $Super+Shift H send-layout-cmd rivertile "main-count +1"
+riverctl map normal $Super+Shift L send-layout-cmd rivertile "main-count -1"
 
-# Super+Alt+{H,J,K,L} to move views
-riverctl map normal Super+Alt H move left 100
-riverctl map normal Super+Alt J move down 100
-riverctl map normal Super+Alt K move up 100
-riverctl map normal Super+Alt L move right 100
+# $Super+$Alt+{H,J,K,L} to move views
+riverctl map normal $Super+$Alt H move left 100
+riverctl map normal $Super+$Alt J move down 100
+riverctl map normal $Super+$Alt K move up 100
+riverctl map normal $Super+$Alt L move right 100
 
-# Super+Alt+Control+{H,J,K,L} to snap views to screen edges
-riverctl map normal Super+Alt+Control H snap left
-riverctl map normal Super+Alt+Control J snap down
-riverctl map normal Super+Alt+Control K snap up
-riverctl map normal Super+Alt+Control L snap right
+# $Super+$Alt+Control+{H,J,K,L} to snap views to screen edges
+riverctl map normal $Super+$Alt+Control H snap left
+riverctl map normal $Super+$Alt+Control J snap down
+riverctl map normal $Super+$Alt+Control K snap up
+riverctl map normal $Super+$Alt+Control L snap right
 
-# Super+Alt+Shift+{H,J,K,L} to resize views
-riverctl map normal Super+Alt+Shift H resize horizontal -100
-riverctl map normal Super+Alt+Shift J resize vertical 100
-riverctl map normal Super+Alt+Shift K resize vertical -100
-riverctl map normal Super+Alt+Shift L resize horizontal 100
+# $Super+$Alt+Shift+{H,J,K,L} to resize views
+riverctl map normal $Super+$Alt+Shift H resize horizontal -100
+riverctl map normal $Super+$Alt+Shift J resize vertical 100
+riverctl map normal $Super+$Alt+Shift K resize vertical -100
+riverctl map normal $Super+$Alt+Shift L resize horizontal 100
 
-# Super + Left Mouse Button to move views
-riverctl map-pointer normal Super BTN_LEFT move-view
+# $Super + Left Mouse Button to move views
+riverctl map-pointer normal $Super BTN_LEFT move-view
 
-# Super + Right Mouse Button to resize views
-riverctl map-pointer normal Super BTN_RIGHT resize-view
+# $Super + Right Mouse Button to resize views
+riverctl map-pointer normal $Super BTN_RIGHT resize-view
 
 for i in $(seq 1 9)
 do
     tags=$((1 << ($i - 1)))
 
-    # Super+[1-9] to focus tag [0-8]
-    riverctl map normal Super $i set-focused-tags $tags
+    # $Super+[1-9] to focus tag [0-8]
+    riverctl map normal $Super $i set-focused-tags $tags
 
-    # Super+Shift+[1-9] to tag focused view with tag [0-8]
-    riverctl map normal Super+Shift $i set-view-tags $tags
+    # $Super+Shift+[1-9] to tag focused view with tag [0-8]
+    riverctl map normal $Super+Shift $i set-view-tags $tags
 
-    # Super+Ctrl+[1-9] to toggle focus of tag [0-8]
-    riverctl map normal Super+Control $i toggle-focused-tags $tags
+    # $Super+Ctrl+[1-9] to toggle focus of tag [0-8]
+    riverctl map normal $Super+Control $i toggle-focused-tags $tags
 
-    # Super+Shift+Ctrl+[1-9] to toggle tag [0-8] of focused view
-    riverctl map normal Super+Shift+Control $i toggle-view-tags $tags
+    # $Super+Shift+Ctrl+[1-9] to toggle tag [0-8] of focused view
+    riverctl map normal $Super+Shift+Control $i toggle-view-tags $tags
 done
 
-# Super+0 to focus all tags
-# Super+Shift+0 to tag focused view with all tags
+# $Super+0 to focus all tags
+# $Super+Shift+0 to tag focused view with all tags
 all_tags=$(((1 << 32) - 1))
-riverctl map normal Super 0 set-focused-tags $all_tags
-riverctl map normal Super+Shift 0 set-view-tags $all_tags
+riverctl map normal $Super 0 set-focused-tags $all_tags
+riverctl map normal $Super+Shift 0 set-view-tags $all_tags
 
-# Super+Space to toggle float
-riverctl map normal Super Space toggle-float
+# $Super+Space to toggle float
+riverctl map normal $Super Space toggle-float
 
-# Super+F to toggle fullscreen
-riverctl map normal Super F toggle-fullscreen
+# $Super+F to toggle fullscreen
+riverctl map normal $Super F toggle-fullscreen
 
-# Super+{Up,Right,Down,Left} to change layout orientation
-riverctl map normal Super Up    send-layout-cmd rivertile "main-location top"
-riverctl map normal Super Right send-layout-cmd rivertile "main-location right"
-riverctl map normal Super Down  send-layout-cmd rivertile "main-location bottom"
-riverctl map normal Super Left  send-layout-cmd rivertile "main-location left"
+# $Super+{Up,Right,Down,Left} to change layout orientation
+riverctl map normal $Super Up    send-layout-cmd rivertile "main-location top"
+riverctl map normal $Super Right send-layout-cmd rivertile "main-location right"
+riverctl map normal $Super Down  send-layout-cmd rivertile "main-location bottom"
+riverctl map normal $Super Left  send-layout-cmd rivertile "main-location left"
 
 # Declare a passthrough mode. This mode has only a single mapping to return to
 # normal mode. This makes it useful for testing a nested wayland compositor
 riverctl declare-mode passthrough
 
-# Super+F11 to enter passthrough mode
-riverctl map normal Super F11 enter-mode passthrough
+# $Super+F11 to enter passthrough mode
+riverctl map normal $Super F11 enter-mode passthrough
 
-# Super+F11 to return to normal mode
-riverctl map passthrough Super F11 enter-mode normal
+# $Super+F11 to return to normal mode
+riverctl map passthrough $Super F11 enter-mode normal
 
 # Various media key mapping examples for both normal and locked mode which do
 # not have a modifier
@@ -157,4 +160,4 @@ riverctl csd-filter-add app-id "gedit"
 # Set and exec into the default layout generator, rivertile.
 # River will send the process group of the init executable SIGTERM on exit.
 riverctl default-layout rivertile
-exec rivertile -view-padding 6 -outer-padding 6
+exec rivertile -view-padding 6 -outer-padding 6 &

--- a/example/init
+++ b/example/init
@@ -160,4 +160,4 @@ riverctl csd-filter-add app-id "gedit"
 # Set and exec into the default layout generator, rivertile.
 # River will send the process group of the init executable SIGTERM on exit.
 riverctl default-layout rivertile
-exec rivertile -view-padding 6 -outer-padding 6 &
+exec rivertile -view-padding 6 -outer-padding 6 


### PR DESCRIPTION
This pr solves the issue with the default init script calling 'Super' as a modifer which doesnt work, now the script maps the variable '$Super' to Mod4 which solves the problem