### PR TITLE
Cursor: fix focus for Xwayland override redirect windows

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -316,10 +316,9 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
                 }
             },
             .xwayland_override_redirect => |override_redirect| {
-                if (build_options.xwayland) {
+                if (!build_options.xwayland) unreachable;
+                if (override_redirect.xwayland_surface.overrideRedirectWantsFocus()) {
                     self.seat.setFocusRaw(.{ .xwayland_override_redirect = override_redirect });
-                } else {
-                    unreachable;
                 }
             },
         }


### PR DESCRIPTION
I neglected to check if an Xwayland override redirect window actually wants focus on cursor button click in https://github.com/riverwm/river/pull/608. This PR adds that check, which fixes https://github.com/riverwm/river/issues/620 as far as I can tell. (I have checked with Xwayland Firefox as well as VS Code, which was mentioned in the issue, and the popup problems are resolved for me.)