### PR TITLE
Xwayland: restrict OR focus changes based on ICCCM input model

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -317,7 +317,9 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
             },
             .xwayland_override_redirect => |override_redirect| {
                 if (!build_options.xwayland) unreachable;
-                if (override_redirect.xwayland_surface.overrideRedirectWantsFocus()) {
+                if (override_redirect.xwayland_surface.overrideRedirectWantsFocus() and
+                    override_redirect.xwayland_surface.icccmInputModel() != .none)
+                {
                     self.seat.setFocusRaw(.{ .xwayland_override_redirect = override_redirect });
                 }
             },

--- a/river/XwaylandOverrideRedirect.zig
+++ b/river/XwaylandOverrideRedirect.zig
@@ -96,7 +96,9 @@ pub fn handleMap(listener: *wl.Listener(*wlr.XwaylandSurface), xwayland_surface:
 
     xwayland_surface.surface.?.events.commit.add(&self.commit);
 
-    if (self.xwayland_surface.overrideRedirectWantsFocus()) {
+    if (self.xwayland_surface.overrideRedirectWantsFocus() and
+        self.xwayland_surface.icccmInputModel() != .none)
+    {
         server.input_manager.defaultSeat().setFocusRaw(.{ .xwayland_override_redirect = self });
     }
 }


### PR DESCRIPTION
This fixes the remainder of https://github.com/riverwm/river/issues/620, with regard to IntelliJ IDEA popup menus not working (e.g. disappearing immediately on creation). This is done by adding a check to Xwayland OR window focus changes for the window's ICCCM input model, in addition to the wlroots heuristic used before (`overrideRedirectWantsFocus()`), which makes sure that the window can take input focus before assigning focus to it. Keeping the heuristic is required, however, because focus may be incorrectly given to OR windows in other applications (X11 Firefox right-click menus in my testing) if only the ICCCM input model is checked.