### PR TITLE
Xwayland: keep previous view activated when focusing Xwayland OR surfaces

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -367,12 +367,8 @@ fn updateKeyboardFocus(self: Self, result: SurfaceAtResult) void {
             self.seat.setFocusRaw(.{ .lock_surface = lock_surface });
         },
         .xwayland_override_redirect => |override_redirect| {
-            if (!build_options.xwayland) unreachable;
-            if (override_redirect.xwayland_surface.overrideRedirectWantsFocus() and
-                override_redirect.xwayland_surface.icccmInputModel() != .none)
-            {
-                self.seat.setFocusRaw(.{ .xwayland_override_redirect = override_redirect });
-            }
+            assert(server.lock_manager.state != .unlocked);
+            override_redirect.focusIfDesired();
         },
     }
 }
@@ -663,7 +659,7 @@ const SurfaceAtResult = struct {
         view: *View,
         layer_surface: *LayerSurface,
         lock_surface: *LockSurface,
-        xwayland_override_redirect: if (build_options.xwayland) *XwaylandOverrideRedirect else void,
+        xwayland_override_redirect: if (build_options.xwayland) *XwaylandOverrideRedirect else noreturn,
     },
 };
 

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -80,6 +80,9 @@ focused_output: *Output,
 
 focused: FocusTarget = .none,
 
+/// Currently activated Xwayland view (used to handle override redirect menus)
+activated_xwayland_view: if (build_options.xwayland) ?*View else void = if (build_options.xwayland) null else {},
+
 /// Stack of views in most recently focused order
 /// If there is a currently focused view, it is on top.
 focus_stack: ViewStack(*View) = .{},
@@ -230,11 +233,36 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
         .none => null,
     };
 
+    if (build_options.xwayland) {
+        // Keep the parent top-level Xwayland view of any override redirect surface
+        // activated while that override redirect surface is focused. This ensures
+        // override redirect menus do not disappear as a result of deactivating
+        // their parent window.
+        if (new_focus == .xwayland_override_redirect and
+            self.focused == .view and
+            self.focused.view.impl == .xwayland_view and
+            self.focused.view.impl.xwayland_view.xwayland_surface.pid == new_focus.xwayland_override_redirect.xwayland_surface.pid)
+        {
+            self.activated_xwayland_view = self.focused.view;
+        } else if (self.activated_xwayland_view) |active_view| {
+            if (!(new_focus == .view and new_focus.view == active_view) and
+                !(new_focus == .xwayland_override_redirect and new_focus.xwayland_override_redirect.xwayland_surface.pid == active_view.impl.xwayland_view.xwayland_surface.pid))
+            {
+                if (active_view.pending.focus == 0) active_view.setActivated(false);
+                self.activated_xwayland_view = null;
+            }
+        }
+    }
+
     // First clear the current focus
     switch (self.focused) {
         .view => |view| {
             view.pending.focus -= 1;
-            if (view.pending.focus == 0) view.setActivated(false);
+            if (view.pending.focus == 0 and
+                (!build_options.xwayland or view != self.activated_xwayland_view))
+            {
+                view.setActivated(false);
+            }
         },
         .xwayland_override_redirect, .layer, .lock_surface, .none => {},
     }
@@ -244,7 +272,11 @@ pub fn setFocusRaw(self: *Self, new_focus: FocusTarget) void {
         .view => |target_view| {
             assert(server.lock_manager.state == .unlocked);
             assert(self.focused_output == target_view.output);
-            if (target_view.pending.focus == 0) target_view.setActivated(true);
+            if (target_view.pending.focus == 0 and
+                (!build_options.xwayland or target_view != self.activated_xwayland_view))
+            {
+                target_view.setActivated(true);
+            }
             target_view.pending.focus += 1;
             target_view.pending.urgent = false;
         },

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -175,16 +175,6 @@ pub fn getConstraints(self: Self) View.Constraints {
 /// Called when the xwayland surface is destroyed
 fn handleDestroy(listener: *wl.Listener(*wlr.XwaylandSurface), _: *wlr.XwaylandSurface) void {
     const self = @fieldParentPtr(Self, "destroy", listener);
-    const view = self.view;
-
-    // Ensure no seat will attempt to access this view after it is destroyed.
-    var seat_it = server.input_manager.seats.first;
-    while (seat_it) |seat_node| : (seat_it = seat_node.next) {
-        const seat = &seat_node.data;
-        if (seat.activated_xwayland_view == view) {
-            seat.activated_xwayland_view = null;
-        }
-    }
 
     // Remove listeners that are active for the entire lifetime of the view
     self.destroy.link.remove();

--- a/river/XwaylandView.zig
+++ b/river/XwaylandView.zig
@@ -175,6 +175,16 @@ pub fn getConstraints(self: Self) View.Constraints {
 /// Called when the xwayland surface is destroyed
 fn handleDestroy(listener: *wl.Listener(*wlr.XwaylandSurface), _: *wlr.XwaylandSurface) void {
     const self = @fieldParentPtr(Self, "destroy", listener);
+    const view = self.view;
+
+    // Ensure no seat will attempt to access this view after it is destroyed.
+    var seat_it = server.input_manager.seats.first;
+    while (seat_it) |seat_node| : (seat_it = seat_node.next) {
+        const seat = &seat_node.data;
+        if (seat.activated_xwayland_view == view) {
+            seat.activated_xwayland_view = null;
+        }
+    }
 
     // Remove listeners that are active for the entire lifetime of the view
     self.destroy.link.remove();


### PR DESCRIPTION
I have looked into https://github.com/riverwm/river/issues/620 again and more deeply, and I believe I have found a final solution. I feel, however, that it can be improved because it is not in keeping with river's normal behaviour. Specifically, two views can be activated at the same time: If an Xwayland override redirect surface takes focus and a normal view was in focus previously, the previous view's focus will *not* be removed; the focus for this view is only reset if a new view takes focus over the override redirect surface. This ensures that when an Xwayland popup menu (or similar) is created, its parent Xwayland view is still activated, allowing the menu to continue its operation. (Perhaps deactivating the parent view implies that the view's popup menu should no longer be shown?) Please note that this applies to any previously focused view, not only to an override redirect surface's parent view. For example, if dmenu is run while a foot window is currently focused, the foot window will still be activated (with keyboard input given to dmenu) until focus is set to another view (possibly the original foot window). I implemented this generalised case for simplicity, as opposed to checking if the currently focused view is the parent of the newly focused override redirect surface.

My solution was inspired by sway's handling of focus, where the previous focus is not unset if the seat's focus is set directly to a surface (see https://github.com/swaywm/sway/blob/master/sway/input/seat.c#L1300). This was the main difference in logic I found between sway and river which seemed to explain the disparity in Xwayland popup menu behaviour.

From my testing, it should also no longer be necessary to check for an override redirect surface's ICCCM input model, but I have left the checks as they do not appear to impact the required popup menu functionality. (Some popup menus also passed the checks when they likely should not have, such as those of qt6ct---mentioned by @Bonicgamer in the linked issue---which passed the `overrideRedirectWantsFocus()` heuristic and has a local input model; and of winecfg, which also passed the heuristic but has a global input model. This inconsistency in advertised window type and input model properties made me look more closely at sway's codebase for a possible solution.)

If this patch could be tested to make sure no further bugs are introduced (such as from having two views activated simultaneously) and Xwayland menus are working appropriately, that would be much appreciated.