### PR TITLE
ci: explicitly install libevdev

### DIFF
--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -1,5 +1,6 @@
 image: archlinux
 packages:
+  - libevdev
   - libinput
   - libxkbcommon
   - mesa

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -1,6 +1,7 @@
 image: freebsd/latest
 packages:
   - devel/evdev-proto
+  - devel/libevdev
   - devel/libepoll-shim
   - devel/libudev-devd
   - devel/meson

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,7 +27,8 @@ jobs:
             libffi-devel wayland-protocols xcb-util-errors-devel xcb-util-wm-devel \
             xcb-util-renderutil-devel libxcb-devel xcb-util-cursor-devel xcb-util-devel \
             xcb-util-image-devel xcb-util-keysyms-devel xcb-util-xrm-devel \
-            xorg-server-xwayland pkg-config meson git gcc pkgconf scdoc wget tar xz
+            xorg-server-xwayland pkg-config meson git gcc pkgconf scdoc wget tar xz \
+            libevdev-devel
 
           git clone https://gitlab.freedesktop.org/wayland/wayland.git
           cd wayland


### PR DESCRIPTION
This is currently pulled in transitively on void, arch, and FreeBSD
which just stopped working on void due to upstream changes.