### PR TITLE
rivertile: Add command to mutate padding during runtime

### DIFF
--- a/doc/rivertile.1.scd
+++ b/doc/rivertile.1.scd
@@ -62,6 +62,10 @@ These commands may be sent to rivertile at runtime with the help of
 	_value_. Note that the ratio will always be clamped to the range
 	0.1 to 0.9.
 
+*padding* [*on*|*off*|*toggle*]
+	Set or toggle view and outer padding. On or off will set the padding
+	accordingly, while toggle will switch between the two.
+
 # EXAMPLES
 
 Start *rivertile* with 4 pixels outer padding and the *top* main location:

--- a/example/init
+++ b/example/init
@@ -47,6 +47,9 @@ riverctl map normal Super L send-layout-cmd rivertile "main-ratio +0.05"
 riverctl map normal Super+Shift H send-layout-cmd rivertile "main-count +1"
 riverctl map normal Super+Shift L send-layout-cmd rivertile "main-count -1"
 
+# Super + G will toggle padding on and off
+riverctl map normal Super G send-layout-cmd rivertile "padding toggle"
+
 # Super+Alt+{H,J,K,L} to move views
 riverctl map normal Super+Alt H move left 100
 riverctl map normal Super+Alt J move down 100

--- a/rivertile/main.zig
+++ b/rivertile/main.zig
@@ -117,6 +117,9 @@ const Output = struct {
     main_location: Location,
     main_count: u31,
     main_ratio: f64,
+    init_view_padding: u31,
+    init_outer_padding: u31,
+    padding: bool,
 
     layout: *river.LayoutV3 = undefined,
 
@@ -127,6 +130,9 @@ const Output = struct {
             .main_location = default_main_location,
             .main_count = default_main_count,
             .main_ratio = default_main_ratio,
+            .init_view_padding = view_padding,
+            .init_outer_padding = outer_padding,
+            .padding = true,
         };
         if (context.initialized) try output.getLayout(context);
     }

--- a/rivertile/main.zig
+++ b/rivertile/main.zig
@@ -203,6 +203,35 @@ const Output = struct {
                             else => output.main_ratio = math.clamp(arg, 0.1, 0.9),
                         }
                     },
+                    .@"padding" => {
+                        const toggle = std.meta.stringToEnum(Toggle, raw_arg) orelse {
+                            std.log.err("unknown toggle: {s}", .{raw_arg});
+                            return;
+                        };
+                        switch (toggle) {
+                            .@"on" => {
+                                output.padding = true;
+                                view_padding = output.init_view_padding;
+                                outer_padding = output.init_outer_padding;
+                            },
+                            .@"off" => {
+                                output.padding = false;
+                                view_padding = 0;
+                                outer_padding = 0;
+                            },
+                            .@"toggle" => {
+                                if (output.padding) {
+                                    output.padding = false;
+                                    view_padding = 0;
+                                    outer_padding = 0;
+                                } else {
+                                    output.padding = true;
+                                    view_padding = output.init_view_padding;
+                                    outer_padding = output.init_outer_padding;
+                                }
+                            },
+                        }
+                    },
                 }
             },
 

--- a/rivertile/main.zig
+++ b/rivertile/main.zig
@@ -69,6 +69,7 @@ const Command = enum {
     @"main-location",
     @"main-count",
     @"main-ratio",
+    @"padding",
 };
 
 const Location = enum {
@@ -76,6 +77,12 @@ const Location = enum {
     right,
     bottom,
     left,
+};
+
+const Toggle = enum {
+    @"on",
+    @"off",
+    @"toggle",
 };
 
 // Configured through command line options


### PR DESCRIPTION
Hi all! This PR adds a new command to `rivertile`, `padding` that allows updating padding during runtime. This was a feature I had wanted from river for a while, and had maintained a separate patch, but figured I should upstream this feature if it was desired.

My implementation treats padding as a boolean, allowing `send-layout-cmd rivertile padding {on,off,toggle}` to toggle padding (both view _and_ outer) on and off. I debated implementing this command to take an integer as input, similar to how main-count and ratio work, and would be happy to rework the PR if this format is preferred.

I'm new to `river` development and zig in general, so please do respond with (constructive) criticism! Of course, if this feature is out of scope for a minimal layout generator like `rivertile`, I absolutely understand.