### PR TITLE
feature: cursor follows focus

### DIFF
--- a/river/Config.zig
+++ b/river/Config.zig
@@ -33,6 +33,11 @@ pub const FocusFollowsCursorMode = enum {
     always,
 };
 
+pub const CursorFollowsFocusMode = enum {
+    disabled,
+    enabled,
+};
+
 pub const WarpCursorMode = enum {
     disabled,
     @"on-output-change",
@@ -75,6 +80,9 @@ csd_filter_titles: std.StringHashMapUnmanaged(void) = .{},
 
 /// The selected focus_follows_cursor mode
 focus_follows_cursor: FocusFollowsCursorMode = .disabled,
+
+/// The selected cursor_follows_focus mode
+cursor_follows_focus: CursorFollowsFocusMode = .disabled,
 
 /// If true, the cursor warps to the center of the focused output
 warp_cursor: WarpCursorMode = .disabled,

--- a/river/command.zig
+++ b/river/command.zig
@@ -49,6 +49,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "close",                     @import("command/close.zig").close },
         .{ "csd-filter-add",            @import("command/filter.zig").csdFilterAdd },
         .{ "csd-filter-remove",         @import("command/filter.zig").csdFilterRemove },
+        .{ "cursor-follows-focus",      @import("command/cursor_follows_focus.zig").cursorFollowsFocus },
         .{ "declare-mode",              @import("command/declare_mode.zig").declareMode },
         .{ "default-layout",            @import("command/layout.zig").defaultLayout },
         .{ "enter-mode",                @import("command/enter_mode.zig").enterMode },

--- a/river/command/cursor_follows_focus.zig
+++ b/river/command/cursor_follows_focus.zig
@@ -1,0 +1,35 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+
+const server = &@import("../main.zig").server;
+
+const Config = @import("../Config.zig");
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+
+pub fn cursorFollowsFocus(
+    _: *Seat,
+    args: []const [:0]const u8,
+    _: *?[]const u8,
+) Error!void {
+    if (args.len < 2) return Error.NotEnoughArguments;
+    if (args.len > 2) return Error.TooManyArguments;
+
+    server.config.cursor_follows_focus =
+        std.meta.stringToEnum(Config.CursorFollowsFocusMode, args[1]) orelse return Error.UnknownOption;
+}

--- a/river/command/focus_view.zig
+++ b/river/command/focus_view.zig
@@ -52,6 +52,13 @@ pub fn focusView(
         _ = it.next();
         // Focus the next visible node if there is one
         if (it.next()) |view| {
+            switch (server.config.cursor_follows_focus) {
+                .disabled => {},
+                .enabled => {
+                    seat.cursor.wlr_cursor.x = @intToFloat(f64, view.pending.box.x) + @intToFloat(f64, view.pending.box.width) / 2.0;
+                    seat.cursor.wlr_cursor.y = @intToFloat(f64, view.pending.box.y) + @intToFloat(f64, view.pending.box.height) / 2.0;
+                }
+            }
             seat.focus(view);
             server.root.startTransaction();
             return;
@@ -65,7 +72,16 @@ pub fn focusView(
         .previous => ViewStack(View).iter(output.views.last, .reverse, output.pending.tags, filter),
     };
 
-    seat.focus(it.next());
+    if (it.next()) |view| {
+        switch (server.config.cursor_follows_focus) {
+            .disabled => {},
+            .enabled => {
+                seat.cursor.wlr_cursor.x = @intToFloat(f64, view.pending.box.x) + @intToFloat(f64, view.pending.box.width) / 2.0;
+                seat.cursor.wlr_cursor.y = @intToFloat(f64, view.pending.box.y) + @intToFloat(f64, view.pending.box.height) / 2.0;
+            }
+        }
+        seat.focus(view);
+    }
     server.root.startTransaction();
 }
 

--- a/river/command/focus_view.zig
+++ b/river/command/focus_view.zig
@@ -57,7 +57,7 @@ pub fn focusView(
                 .enabled => {
                     seat.cursor.wlr_cursor.x = @intToFloat(f64, view.pending.box.x) + @intToFloat(f64, view.pending.box.width) / 2.0;
                     seat.cursor.wlr_cursor.y = @intToFloat(f64, view.pending.box.y) + @intToFloat(f64, view.pending.box.height) / 2.0;
-                }
+                },
             }
             seat.focus(view);
             server.root.startTransaction();
@@ -78,7 +78,7 @@ pub fn focusView(
             .enabled => {
                 seat.cursor.wlr_cursor.x = @intToFloat(f64, view.pending.box.x) + @intToFloat(f64, view.pending.box.width) / 2.0;
                 seat.cursor.wlr_cursor.y = @intToFloat(f64, view.pending.box.y) + @intToFloat(f64, view.pending.box.height) / 2.0;
-            }
+            },
         }
         seat.focus(view);
     }


### PR DESCRIPTION
adds a new option for the cursor to be able to follow new focuses(i.e. via `riverctl focus-view next`)
copied some code from https://github.com/riverwm/river/issues/544
closes https://github.com/riverwm/river/issues/349