### PR TITLE
view: log app-id on map and unmap

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -32,7 +32,8 @@ over the Wayland protocol.
 	Add _pattern_ to the CSD filter list. Views with this _pattern_ are told to
 	use client side decoration instead of the default server side decoration.
 	Note that this affects new views as well as already existing ones. Title
-	updates are not taken into account.
+	updates are not taken into account. app-id may be determined by running
+	river with *-log-level debug* and looking at "info(view)".
 
 *csd-filter-remove* *app-id*|*title* _pattern_
 	Remove _pattern_ from the CSD filter list. Note that this affects new views

--- a/river/View.zig
+++ b/river/View.zig
@@ -480,7 +480,7 @@ pub fn shouldTrackConfigure(self: Self) bool {
 
 /// Called by the impl when the surface is ready to be displayed
 pub fn map(self: *Self) !void {
-    log.debug("view '{s}' mapped", .{self.getTitle()});
+    log.debug("view app-id='{s}' title='{s}' mapped", .{self.getAppId(), self.getTitle()});
 
     {
         assert(self.foreign_toplevel_handle == null);
@@ -518,7 +518,7 @@ pub fn map(self: *Self) !void {
 
 /// Called by the impl when the surface will no longer be displayed
 pub fn unmap(self: *Self) void {
-    log.debug("view '{s}' unmapped", .{self.getTitle()});
+    log.debug("view app-id='{s}' title='{s}' unmapped", .{self.getAppId(), self.getTitle()});
 
     if (self.saved_buffers.items.len == 0) self.saveBuffers();
 

--- a/river/View.zig
+++ b/river/View.zig
@@ -480,7 +480,7 @@ pub fn shouldTrackConfigure(self: Self) bool {
 
 /// Called by the impl when the surface is ready to be displayed
 pub fn map(self: *Self) !void {
-    log.debug("view app-id='{s}' title='{s}' mapped", .{self.getAppId(), self.getTitle()});
+    log.debug("view app-id='{s}' title='{s}' mapped", .{ self.getAppId(), self.getTitle() });
 
     {
         assert(self.foreign_toplevel_handle == null);
@@ -518,7 +518,7 @@ pub fn map(self: *Self) !void {
 
 /// Called by the impl when the surface will no longer be displayed
 pub fn unmap(self: *Self) void {
-    log.debug("view app-id='{s}' title='{s}' unmapped", .{self.getAppId(), self.getTitle()});
+    log.debug("view app-id='{s}' title='{s}' unmapped", .{ self.getAppId(), self.getTitle() });
 
     if (self.saved_buffers.items.len == 0) self.saveBuffers();
 


### PR DESCRIPTION
There is no means to determine app-id, as there is no wayland equivalent of xprop.

Log app-id as well as title.