### PR TITLE
river: implement keyboard groups

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -3,6 +3,9 @@ function __riverctl_completion ()
 	if [ "${COMP_CWORD}" -eq 1 ]
 	then
 		OPTS=" \
+			keyboard-group-create \
+			keyboard-group-destroy \
+			keyboard-group-add-keyboard \
 			csd-filter-add \
 			exit \
 			float-filter-add \

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -61,6 +61,10 @@ complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'hide-cursor'    
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'set-repeat'             -d 'Set the keyboard repeat rate and repeat delay'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'set-cursor-warp'        -d 'Set the cursor warp mode.'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'xcursor-theme'          -d 'Set the xcursor theme'
+# Keyboardgroups
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'keyboard-group-create'       -d 'Create a keyboard group.'
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'keyboard-group-destroy'      -d 'Destroy a keyboard group.'
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'keyboard-group-add-keyboard' -d 'Add a keyboard to a keyboard group.'
 
 # Subcommands
 complete -c riverctl -x -n '__fish_seen_subcommand_from focus-output'         -a 'next previous'

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -55,6 +55,10 @@ _riverctl_subcommands()
         'set-repeat:Set the keyboard repeat rate and repeat delay'
         'set-cursor-warp:Set the cursor warp mode.'
         'xcursor-theme:Set the xcursor theme'
+        # Keyboard groups
+        'keyboard-group-create:Create a keyboard group'
+        'keyboard-group-destroy:Destroy a keyboard group'
+        'keyboard-group-add-keyboard:Add a keyboard to a keyboard group'
         # Input
         'input:Configure input devices'
         'list-inputs:List all input devices'

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -330,6 +330,20 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 *list-input-configs*
 	List all input configurations.
 
+*keyboard-group-create* _keyboard_group_name_
+	Create a keyboard group. A keyboard group collects multiple keyboards in
+	a single logical keyboard. This means that all state, like the active
+	modifiers, is shared between the keyboards in a group.
+
+*keyboard-group-destroy* _keyboard_group_name_
+	Destroy the keyboard group of the given name. All attached keyboards
+	will be released, making them act as seperate devices again.
+
+*keyboard-group-add-keyboard* _keyboard_group_name_ _input_device_identifier_
+	Add a keyboard to a keyboard group, identified by the keyboards input
+	device identifier. Any currently connected and future keyboards matching
+	the identifier will be added to the group.
+
 The _input_ command can be used to create a configuration rule for an input
 device identified by its _name_.
 The _name_ of an input device consists of its type, its numerical vendor id,

--- a/river/InputDevice.zig
+++ b/river/InputDevice.zig
@@ -108,7 +108,7 @@ fn handleDestroy(listener: *wl.Listener(*wlr.InputDevice), _: *wlr.InputDevice) 
 
     switch (device.wlr_device.type) {
         .keyboard => {
-            const keyboard = @fieldParentPtr(Keyboard, "device", device);
+            const keyboard = @fieldParentPtr(Keyboard, "provider", @ptrCast(*Keyboard.Provider, device));
             keyboard.deinit();
             util.gpa.destroy(keyboard);
         },

--- a/river/KeyboardGroup.zig
+++ b/river/KeyboardGroup.zig
@@ -1,0 +1,113 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2022 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const Self = @This();
+
+const std = @import("std");
+const heap = std.heap;
+const mem = std.mem;
+const debug = std.debug;
+const wlr = @import("wlroots");
+const wl = @import("wayland").server.wl;
+const xkb = @import("xkbcommon");
+
+const log = std.log.scoped(.keyboard_group);
+
+const server = &@import("main.zig").server;
+const util = @import("util.zig");
+
+const Seat = @import("Seat.zig");
+const Keyboard = @import("Keyboard.zig");
+
+seat: *Seat,
+group: *wlr.KeyboardGroup,
+name: []const u8,
+keyboard_identifiers: std.ArrayListUnmanaged([]const u8) = .{},
+
+pub fn init(self: *Self, seat: *Seat, _name: []const u8) !void {
+    log.debug("new keyboard group: '{s}'", .{_name});
+
+    const group = try wlr.KeyboardGroup.create();
+    errdefer group.destroy();
+    group.data = @ptrToInt(self);
+
+    const name = try util.gpa.dupe(u8, _name);
+    errdefer util.gpa.free(name);
+
+    self.* = .{
+        .group = group,
+        .name = name,
+        .seat = seat,
+    };
+
+    seat.addDevice(self.group.input_device);
+    seat.wlr_seat.setKeyboard(self.group.input_device);
+}
+
+pub fn deinit(self: *Self) void {
+    log.debug("removing keyboard group: '{s}'", .{self.name});
+
+    util.gpa.free(self.name);
+    for (self.keyboard_identifiers.items) |id| util.gpa.free(id);
+    self.keyboard_identifiers.deinit(util.gpa);
+
+    // wlroots automatically removes all keyboards from the group.
+    self.group.destroy();
+}
+
+pub fn addKeyboardIdentifier(self: *Self, _id: []const u8) !void {
+    if (containsIdentifier(self, _id)) return;
+    log.debug("keyboard group '{s}' adding identifier: '{s}'", .{ self.name, _id });
+
+    const id = try util.gpa.dupe(u8, _id);
+    errdefer util.gpa.free(id);
+    try self.keyboard_identifiers.append(util.gpa, id);
+
+    // Add any existing matching keyboard to group.
+    var it = server.input_manager.devices.iterator(.forward);
+    while (it.next()) |device| {
+        if (device.seat != self.seat) continue;
+        if (device.wlr_device.type != .keyboard) continue;
+
+        if (mem.eql(u8, _id, device.identifier)) {
+            log.debug("found existing matching keyboard; adding to group", .{});
+
+            const wlr_keyboard = device.wlr_device.device.keyboard;
+            if (!self.group.addKeyboard(wlr_keyboard)) continue; // wlroots logs its own errors.
+        }
+
+        // Continue, because we may have more than one device with the exact
+        // same identifier. That is in fact the reason for the keyboard group
+        // feature to exist in the first place.
+    }
+}
+
+pub fn containsIdentifier(self: *Self, id: []const u8) bool {
+    for (self.keyboard_identifiers.items) |ki| {
+        if (mem.eql(u8, ki, id)) return true;
+    }
+    return false;
+}
+
+pub fn addKeyboard(self: *Self, keyboard: *Keyboard) !void {
+    debug.assert(keyboard.provider != .group);
+    const wlr_keyboard = keyboard.provider.device.wlr_device.device.keyboard;
+    log.debug("keyboard group '{s}' adding keyboard: '{s}'", .{ self.name, keyboard.provider.device.identifier });
+    if (!self.group.addKeyboard(wlr_keyboard)) {
+        log.err("failed to add keyboard to group", .{});
+        return error.OutOfMemory;
+    }
+}

--- a/river/command.zig
+++ b/river/command.zig
@@ -89,6 +89,9 @@ const command_impls = std.ComptimeStringMap(
         .{ "unmap-switch",              @import("command/map.zig").unmapSwitch },
         .{ "xcursor-theme",             @import("command/xcursor_theme.zig").xcursorTheme },
         .{ "zoom",                      @import("command/zoom.zig").zoom },
+        .{ "keyboard-group-create",     @import("command/keyboard_group.zig").keyboardGroupCreate},
+        .{ "keyboard-group-destroy",    @import("command/keyboard_group.zig").keyboardGroupDestroy},
+        .{ "keyboard-group-add-keyboard", @import("command/keyboard_group.zig").keyboardGroupAddIdentifier},
     },
 );
 // zig fmt: on

--- a/river/command/keyboard_group.zig
+++ b/river/command/keyboard_group.zig
@@ -1,0 +1,90 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2022 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const std = @import("std");
+const mem = std.mem;
+
+const server = &@import("../main.zig").server;
+const util = @import("../util.zig");
+
+const Error = @import("../command.zig").Error;
+const Seat = @import("../Seat.zig");
+const KeyboardGroup = @import("../KeyboardGroup.zig");
+
+pub fn keyboardGroupCreate(
+    seat: *Seat,
+    args: []const [:0]const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 2) return Error.NotEnoughArguments;
+    if (args.len > 2) return Error.TooManyArguments;
+
+    var it = seat.keyboard_groups.first;
+    while (it) |node| : (it = node.next) {
+        if (mem.eql(u8, node.data.name, args[1])) {
+            const msg = try util.gpa.dupe(u8, "error: failed to create keybaord group: group of same name already exists\n");
+            out.* = msg;
+            return;
+        }
+    }
+
+    const node = try util.gpa.create(std.TailQueue(KeyboardGroup).Node);
+    errdefer util.gpa.destroy(node);
+    try node.data.init(seat, args[1]);
+    seat.keyboard_groups.append(node);
+}
+
+pub fn keyboardGroupDestroy(
+    seat: *Seat,
+    args: []const [:0]const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 2) return Error.NotEnoughArguments;
+    if (args.len > 2) return Error.TooManyArguments;
+    const kg = keyboardGroupFromName(seat, args[1]) orelse {
+        const msg = try util.gpa.dupe(u8, "error: no keyboard group with that name exists\n");
+        out.* = msg;
+        return;
+    };
+    kg.deinit();
+    const node = @fieldParentPtr(std.TailQueue(KeyboardGroup).Node, "data", kg);
+    seat.keyboard_groups.remove(node);
+    util.gpa.destroy(node);
+}
+
+pub fn keyboardGroupAddIdentifier(
+    seat: *Seat,
+    args: []const [:0]const u8,
+    out: *?[]const u8,
+) Error!void {
+    if (args.len < 3) return Error.NotEnoughArguments;
+    if (args.len > 3) return Error.TooManyArguments;
+
+    const kg = keyboardGroupFromName(seat, args[1]) orelse {
+        const msg = try util.gpa.dupe(u8, "error: no keyboard group with that name exists\n");
+        out.* = msg;
+        return;
+    };
+    try kg.addKeyboardIdentifier(args[2]);
+}
+
+fn keyboardGroupFromName(seat: *Seat, name: []const u8) ?*KeyboardGroup {
+    var it = seat.keyboard_groups.first;
+    while (it) |node| : (it = node.next) {
+        if (mem.eql(u8, node.data.name, name)) return &node.data;
+    }
+    return null;
+}


### PR DESCRIPTION
Usage:
```
riverctl keyboard-group-create <group-name>
riverctl keyboard-group-add-keyboard <group-name> <input-device-identifier>
```

Still a few rough spots, but it works.