### PR TITLE
map-button

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -33,9 +33,11 @@ function __riverctl_completion ()
 			declare-mode \
 			enter-mode \
 			map \
+			map-button \
 			map-pointer \
 			map-switch \
 			unmap \
+			unmap-button \
 			unmap-pointer \
 			unmap-switch \
 			attach-mode \

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -44,9 +44,11 @@ complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'send-to-previous
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'declare-mode'           -d 'Create a new mode'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'enter-mode'             -d 'Switch to given mode if it exists'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'map'                    -d 'Run command when key is pressed while modifiers are held down and in the specified mode'
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'map-button'             -d 'Run command when button is pressed while modifiers are held down and in the specified mode'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'map-pointer'            -d 'Move or resize views when button and modifers are held down while in the specified mode'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'map-switch '            -d 'Run command when river receives a switch event in the specified mode'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'unmap'                  -d 'Remove the mapping defined by the arguments'
+complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'unmap-button'           -d 'Remove the mapping defined by the arguments'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'unmap-pointer'          -d 'Remove the pointer mapping defined by the arguments'
 complete -c riverctl -x -n '__fish_riverctl_complete_arg 1' -a 'unmap-switch'           -d 'Remove the switch mapping defined by the arguments'
 # Configuration

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -38,9 +38,11 @@ _riverctl_subcommands()
         'declare-mode:Create a new mode'
         'enter-mode:Switch to given mode if it exists'
         'map:Run command when key is pressed while modifiers are held down and in the specified mode'
+        'map-button:Run command when button is pressed while modifiers are held down and in the specified mode'
         'map-pointer:Move or resize views when button and modifiers are held down while in the specified mode'
         'map-switch:Run command when river receives a switch event in the specified mode'
         'unmap:Remove the mapping defined by the arguments'
+        'unmap-button:Remove the button mapping defined by the arguments'
         'unmap-pointer:Remove the pointer mapping defined by the arguments'
         'unmap-switch:Remove the switch mapping defined by the arguments'
         # Configuration

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -212,6 +212,16 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	- _key_: an XKB keysym name as described above
 	- _command_: any command that may be run with riverctl
 
+*map-button* _mode_ _modifiers_ _button_ _command_
+	Run _command_ when _button_ is pressed while _modifiers_ are held down
+	and in the specified _mode_.
+
+	- _mode_: name of the mode for which to create the mapping
+	- _modifiers_: one or more of the modifiers listed above, separated
+	  by a plus sign (+).
+	- _button_: the name of a linux input event code as described above
+	- _command_: any command that may be run with riverctl
+
 *map-pointer* _mode_ _modifiers_ _button_ _action_
 	Move or resize views when _button_ and _modifiers_ are held down
 	while in the specified _mode_.
@@ -246,6 +256,14 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	- _modifiers_: one or more of the modifiers listed above, separated
 	  by a plus sign (+).
 	- _key_: an XKB keysym name as described above
+
+*unmap-button* _mode_ _modifiers_ _button_
+	Remove the mapping defined by the arguments:
+
+	- _mode_: name of the mode for which to remove the mapping
+	- _modifiers_: one or more of the modifiers listed above, separated
+	  by a plus sign (+).
+	- _button_: the name of a linux input event code as described above
 
 *unmap-pointer* _mode_ _modifiers_ _button_
 	Remove the pointer mapping defined by the arguments:

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -214,7 +214,7 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 
 *map-button* _mode_ _modifiers_ _button_ _command_
 	Run _command_ when _button_ is pressed while _modifiers_ are held down
-	and in the specified _mode_.
+	and in the specified _mode_. Overrides map-pointer.
 
 	- _mode_: name of the mode for which to create the mapping
 	- _modifiers_: one or more of the modifiers listed above, separated
@@ -224,7 +224,7 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 
 *map-pointer* _mode_ _modifiers_ _button_ _action_
 	Move or resize views when _button_ and _modifiers_ are held down
-	while in the specified _mode_.
+	while in the specified _mode_. Overridden by map-button.
 
 	- _mode_: name of the mode for which to create the mapping
 	- _modifiers_: one or more of the modifiers listed above, separated

--- a/example/init
+++ b/example/init
@@ -65,6 +65,9 @@ riverctl map normal Super+Alt+Shift J resize vertical 100
 riverctl map normal Super+Alt+Shift K resize vertical -100
 riverctl map normal Super+Alt+Shift L resize horizontal 100
 
+# Super + Middle Mouse Button to toggle floating
+riverctl map-button normal Super BTN_MIDDLE toggle-float
+
 # Super + Left Mouse Button to move views
 riverctl map-pointer normal Super BTN_LEFT move-view
 

--- a/river/ButtonMapping.zig
+++ b/river/ButtonMapping.zig
@@ -26,13 +26,9 @@ event_code: u32,
 modifiers: wlr.Keyboard.ModifierMask,
 command_args: []const [:0]const u8,
 
-/// When set to true the mapping will be executed on button release rather than on press
-release: bool,
-
 pub fn init(
     event_code: u32,
     modifiers: wlr.Keyboard.ModifierMask,
-    release: bool,
     command_args: []const []const u8,
 ) !Self {
     const owned_args = try util.gpa.alloc([:0]u8, command_args.len);
@@ -44,7 +40,6 @@ pub fn init(
     return Self{
         .event_code = event_code,
         .modifiers = modifiers,
-        .release = release,
         .command_args = owned_args,
     };
 }
@@ -54,12 +49,11 @@ pub fn deinit(self: Self) void {
     util.gpa.free(self.command_args);
 }
 
-/// Compare mapping with given event code, modifiers and keyboard state
+/// Compare mapping with given event code and modifiers
 pub fn match(
     self: Self,
     event_code: u32,
     modifiers: wlr.Keyboard.ModifierMask,
-    release: bool,
 ) bool {
-    return event_code == self.event_code and std.meta.eql(modifiers, self.modifiers) and release == self.release;
+    return event_code == self.event_code and std.meta.eql(modifiers, self.modifiers);
 }

--- a/river/ButtonMapping.zig
+++ b/river/ButtonMapping.zig
@@ -1,0 +1,65 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2020 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const Self = @This();
+
+const std = @import("std");
+
+const wlr = @import("wlroots");
+
+const util = @import("util.zig");
+
+event_code: u32,
+modifiers: wlr.Keyboard.ModifierMask,
+command_args: []const [:0]const u8,
+
+/// When set to true the mapping will be executed on button release rather than on press
+release: bool,
+
+pub fn init(
+    event_code: u32,
+    modifiers: wlr.Keyboard.ModifierMask,
+    release: bool,
+    command_args: []const []const u8,
+) !Self {
+    const owned_args = try util.gpa.alloc([:0]u8, command_args.len);
+    errdefer util.gpa.free(owned_args);
+    for (command_args) |arg, i| {
+        errdefer for (owned_args[0..i]) |a| util.gpa.free(a);
+        owned_args[i] = try util.gpa.dupeZ(u8, arg);
+    }
+    return Self{
+        .event_code = event_code,
+        .modifiers = modifiers,
+        .release = release,
+        .command_args = owned_args,
+    };
+}
+
+pub fn deinit(self: Self) void {
+    for (self.command_args) |arg| util.gpa.free(arg);
+    util.gpa.free(self.command_args);
+}
+
+/// Compare mapping with given event code, modifiers and keyboard state
+pub fn match(
+    self: Self,
+    event_code: u32,
+    modifiers: wlr.Keyboard.ModifierMask,
+    release: bool,
+) bool {
+    return event_code == self.event_code and std.meta.eql(modifiers, self.modifiers) and release == self.release;
+}

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -311,7 +311,6 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
     }
 
     if (self.handleButtonMapping(event)) {
-        // TODO eaten_event_codes
         return;
     } else if (self.surfaceAt()) |result| {
         if (result.parent == .view and self.handlePointerMapping(event, result.parent.view)) {
@@ -540,7 +539,7 @@ fn handleButtonMapping(self: *Self, event: *wlr.Pointer.event.Button) bool {
     const wlr_keyboard = self.seat.wlr_seat.getKeyboard() orelse return false;
     const modifiers = wlr_keyboard.getModifiers();
 
-    return self.seat.handleButtonMapping(event.button, modifiers, event.state == .released);
+    return self.seat.handleButtonMapping(event.button, modifiers);
 }
 
 /// Frame events are sent after regular pointer events to group multiple

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -310,7 +310,10 @@ fn handleButton(listener: *wl.Listener(*wlr.Pointer.event.Button), event: *wlr.P
         return;
     }
 
-    if (self.surfaceAt()) |result| {
+    if (self.handleButtonMapping(event)) {
+        // TODO eaten_event_codes
+        return;
+    } else if (self.surfaceAt()) |result| {
         if (result.parent == .view and self.handlePointerMapping(event, result.parent.view)) {
             // If a mapping is triggered don't send events to clients.
             return;
@@ -512,7 +515,7 @@ fn handleTouchFrame(listener: *wl.Listener(void)) void {
     self.seat.wlr_seat.touchNotifyFrame();
 }
 
-/// Handle the mapping for the passed button if any. Returns true if there
+/// Handle the pointer mapping for the passed button if any. Returns true if there
 /// was a mapping and the button was handled.
 fn handlePointerMapping(self: *Self, event: *wlr.Pointer.event.Button, view: *View) bool {
     const wlr_keyboard = self.seat.wlr_seat.getKeyboard() orelse return false;
@@ -529,6 +532,15 @@ fn handlePointerMapping(self: *Self, event: *wlr.Pointer.event.Button, view: *Vi
             break true;
         }
     } else false;
+}
+
+/// Handle the button mapping for the passed button if any. Returns true if there
+/// was a mapping.
+fn handleButtonMapping(self: *Self, event: *wlr.Pointer.event.Button) bool {
+    const wlr_keyboard = self.seat.wlr_seat.getKeyboard() orelse return false;
+    const modifiers = wlr_keyboard.getModifiers();
+
+    return self.seat.handleButtonMapping(event.button, modifiers, event.state == .released);
 }
 
 /// Frame events are sent after regular pointer events to group multiple

--- a/river/Mode.zig
+++ b/river/Mode.zig
@@ -20,11 +20,13 @@ const std = @import("std");
 const util = @import("util.zig");
 
 const Mapping = @import("Mapping.zig");
+const ButtonMapping = @import("ButtonMapping.zig");
 const PointerMapping = @import("PointerMapping.zig");
 const SwitchMapping = @import("SwitchMapping.zig");
 
 name: [:0]const u8,
 mappings: std.ArrayListUnmanaged(Mapping) = .{},
+button_mappings: std.ArrayListUnmanaged(ButtonMapping) = .{},
 pointer_mappings: std.ArrayListUnmanaged(PointerMapping) = .{},
 switch_mappings: std.ArrayListUnmanaged(SwitchMapping) = .{},
 
@@ -32,6 +34,7 @@ pub fn deinit(self: *Self) void {
     util.gpa.free(self.name);
     for (self.mappings.items) |m| m.deinit();
     self.mappings.deinit(util.gpa);
+    self.button_mappings.deinit(util.gpa);
     self.pointer_mappings.deinit(util.gpa);
     self.switch_mappings.deinit(util.gpa);
 }

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -405,6 +405,26 @@ pub fn handleMapping(
     return handled;
 }
 
+/// Handle any user-defined mapping for passed button, modifiers and keyboard state.
+/// Returns true if there was a mapping.
+pub fn handleButtonMapping(
+    self: *Self,
+    event_code: u32,
+    modifiers: wlr.Keyboard.ModifierMask,
+    released: bool,
+) bool {
+    const modes = &server.config.modes;
+    for (modes.items[self.mode_id].button_mappings.items) |*mapping| {
+        if (mapping.event_code == event_code and std.meta.eql(mapping.modifiers, modifiers)) {
+            if (mapping.release == released) {
+                self.runCommand(mapping.command_args);
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
 /// Handle any user-defined mapping for switches
 pub fn handleSwitchMapping(
     self: *Self,

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -411,14 +411,11 @@ pub fn handleButtonMapping(
     self: *Self,
     event_code: u32,
     modifiers: wlr.Keyboard.ModifierMask,
-    released: bool,
 ) bool {
     const modes = &server.config.modes;
     for (modes.items[self.mode_id].button_mappings.items) |*mapping| {
-        if (mapping.event_code == event_code and std.meta.eql(mapping.modifiers, modifiers)) {
-            if (mapping.release == released) {
-                self.runCommand(mapping.command_args);
-            }
+        if (mapping.match(event_code, modifiers)) {
+            self.runCommand(mapping.command_args);
             return true;
         }
     }

--- a/river/Seat.zig
+++ b/river/Seat.zig
@@ -405,7 +405,7 @@ pub fn handleMapping(
     return handled;
 }
 
-/// Handle any user-defined mapping for passed button, modifiers and keyboard state.
+/// Handle any user-defined mapping for passed button and modifiers.
 /// Returns true if there was a mapping.
 pub fn handleButtonMapping(
     self: *Self,

--- a/river/command.zig
+++ b/river/command.zig
@@ -86,7 +86,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "toggle-fullscreen",         @import("command/toggle_fullscreen.zig").toggleFullscreen },
         .{ "toggle-view-tags",          @import("command/tags.zig").toggleViewTags },
         .{ "unmap",                     @import("command/map.zig").unmap },
-        // TODO AMC unmap-button
+        .{ "unmap-button",              @import("command/map.zig").unmapButton },
         .{ "unmap-pointer",             @import("command/map.zig").unmapPointer },
         .{ "unmap-switch",              @import("command/map.zig").unmapSwitch },
         .{ "xcursor-theme",             @import("command/xcursor_theme.zig").xcursorTheme },

--- a/river/command.zig
+++ b/river/command.zig
@@ -64,6 +64,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "list-input-configs",        @import("command/input.zig").listInputConfigs},
         .{ "list-inputs",               @import("command/input.zig").listInputs },
         .{ "map",                       @import("command/map.zig").map },
+        .{ "map-button",                @import("command/map.zig").mapButton },
         .{ "map-pointer",               @import("command/map.zig").mapPointer },
         .{ "map-switch",                @import("command/map.zig").mapSwitch },
         .{ "move",                      @import("command/move.zig").move },
@@ -85,6 +86,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "toggle-fullscreen",         @import("command/toggle_fullscreen.zig").toggleFullscreen },
         .{ "toggle-view-tags",          @import("command/tags.zig").toggleViewTags },
         .{ "unmap",                     @import("command/map.zig").unmap },
+        // TODO AMC unmap-button
         .{ "unmap-pointer",             @import("command/map.zig").unmapPointer },
         .{ "unmap-switch",              @import("command/map.zig").unmapSwitch },
         .{ "xcursor-theme",             @import("command/xcursor_theme.zig").xcursorTheme },


### PR DESCRIPTION
resolves #685 

Adds `map-button` and `unmap-button`: executes a command similar to `map`, using an event code instead of a keysym.

Does not feature `[-release|-repeat|-layout index]`.

Silently overrides `map-pointer`. Please advised whether a warning or automatic `unmap-pointer` is required.

First time using zig; pointers and corrections would be gratefully appreciated.