### PR TITLE
river: predefine tags for app-id and title

### DIFF
--- a/river/Config.zig
+++ b/river/Config.zig
@@ -179,18 +179,19 @@ pub fn getSpawnTagsFilter(self: Self, view: *View) u32 {
     const tags_curr = view.output.current.tags;
     const tags_mask = view.output.spawn_tagmask;
     const tags = tags_curr & tags_mask;
-    
+
     if (view.getAppId()) |app_id| {
-        if(self.spawn_tags_app_ids.contains(std.mem.span(app_id))) {
+        if (self.spawn_tags_app_ids.contains(std.mem.span(app_id))) {
             return self.spawn_tags_app_ids.get(std.mem.span(app_id)) orelse tags;
         }
     }
 
     if (view.getTitle()) |title| {
-        if(self.spawn_tags_titles.contains(std.mem.span(title))) {
+        if (self.spawn_tags_titles.contains(std.mem.span(title))) {
             return self.spawn_tags_titles.get(std.mem.span(title)) orelse tags;
         }
     }
+
     if (tags != 0) {
         return tags;
     } else {

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -73,6 +73,10 @@ float_filter_titles: std.StringHashMapUnmanaged(void) = .{},
 csd_filter_app_ids: std.StringHashMapUnmanaged(void) = .{},
 csd_filter_titles: std.StringHashMapUnmanaged(void) = .{},
 
+/// Maps of app_ids and titles with their assigned tags 
+spawn_tags_app_ids: std.StringHashMapUnmanaged(u32) = .{},
+spawn_tags_titles: std.StringHashMapUnmanaged(u32) = .{},
+
 /// The selected focus_follows_cursor mode
 focus_follows_cursor: FocusFollowsCursorMode = .disabled,
 
@@ -169,6 +173,29 @@ pub fn shouldFloat(self: Self, view: *View) bool {
     }
 
     return false;
+}
+
+pub fn getSpawnTagsFilter(self: Self, view: *View) u32 {
+    const tags_curr = view.output.current.tags;
+    const tags_mask = view.output.spawn_tagmask;
+    const tags = tags_curr & tags_mask;
+    
+    if (view.getAppId()) |app_id| {
+        if(self.spawn_tags_app_ids.contains(std.mem.span(app_id))) {
+            return self.spawn_tags_app_ids.get(std.mem.span(app_id)) orelse tags;
+        }
+    }
+
+    if (view.getTitle()) |title| {
+        if(self.spawn_tags_titles.contains(std.mem.span(title))) {
+            return self.spawn_tags_titles.get(std.mem.span(title)) orelse tags;
+        }
+    }
+    if (tags != 0) {
+        return tags;
+    } else {
+        return tags_curr;
+    }
 }
 
 pub fn csdAllowed(self: Self, view: *View) bool {

--- a/river/View.zig
+++ b/river/View.zig
@@ -494,6 +494,9 @@ pub fn map(self: *Self) !void {
         if (self.getTitle()) |s| handle.setTitle(s);
         if (self.getAppId()) |s| handle.setAppId(s);
 
+        self.pending.tags = server.config.getSpawnTagsFilter(self);
+        self.applyPending();
+
         handle.outputEnter(self.output.wlr_output);
     }
 

--- a/river/command.zig
+++ b/river/command.zig
@@ -76,6 +76,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "set-focused-tags",          @import("command/tags.zig").setFocusedTags },
         .{ "set-repeat",                @import("command/set_repeat.zig").setRepeat },
         .{ "set-view-tags",             @import("command/tags.zig").setViewTags },
+        .{ "spawn-tags-filter",         @import("command/filter.zig").spawnTagsFilter },
         .{ "snap",                      @import("command/move.zig").snap },
         .{ "spawn",                     @import("command/spawn.zig").spawn },
         .{ "spawn-tagmask",             @import("command/tags.zig").spawnTagmask },


### PR DESCRIPTION
Related issues: #201 #472 

This PR adds a command to `riverctl`. The objective being to pre-define tags for app-id's and titles (similarly to how it is done for floating).

Usage example: `riverctl spawn-tags-filter app-id "kitty" 4` 

