### PR TITLE
Global spawn-tagmask

### DIFF
--- a/river/Config.zig
+++ b/river/Config.zig
@@ -85,6 +85,9 @@ warp_cursor: WarpCursorMode = .disabled,
 /// Output.layout_namespace is null.
 default_layout_namespace: []const u8 = &[0]u8{},
 
+/// Bitmask that whitelists tags for newly spawned views
+spawn_tagmask: u32 = std.math.maxInt(u32),
+
 /// Determines where new views will be attached to the view stack.
 attach_mode: AttachMode = .top,
 

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -91,6 +91,9 @@ layout_namespace: ?[]const u8 = null,
 /// The last set layout name.
 layout_name: ?[:0]const u8 = null,
 
+/// Bitmask that whitelists tags for newly spawned views
+spawn_tagmask: u32 = math.maxInt(u32),
+
 /// List of status tracking objects relaying changes to this output to clients.
 status_trackers: std.SinglyLinkedList(OutputStatus) = .{},
 

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -91,9 +91,6 @@ layout_namespace: ?[]const u8 = null,
 /// The last set layout name.
 layout_name: ?[:0]const u8 = null,
 
-/// Bitmask that whitelists tags for newly spawned views
-spawn_tagmask: u32 = math.maxInt(u32),
-
 /// List of status tracking objects relaying changes to this output to clients.
 status_trackers: std.SinglyLinkedList(OutputStatus) = .{},
 

--- a/river/View.zig
+++ b/river/View.zig
@@ -127,7 +127,7 @@ request_activate: wl.Listener(*wlr.XdgActivationV1.event.RequestActivate) =
 
 pub fn init(self: *Self, output: *Output, impl: Impl) void {
     const initial_tags = blk: {
-        const tags = output.current.tags & server.config.spawn_tagmask;
+        const tags = output.current.tags & server.config.spawn_tagmask & output.spawn_tagmask;
         break :blk if (tags != 0) tags else output.current.tags;
     };
 

--- a/river/View.zig
+++ b/river/View.zig
@@ -127,7 +127,7 @@ request_activate: wl.Listener(*wlr.XdgActivationV1.event.RequestActivate) =
 
 pub fn init(self: *Self, output: *Output, impl: Impl) void {
     const initial_tags = blk: {
-        const tags = output.current.tags & output.spawn_tagmask;
+        const tags = output.current.tags & server.config.spawn_tagmask;
         break :blk if (tags != 0) tags else output.current.tags;
     };
 

--- a/river/command.zig
+++ b/river/command.zig
@@ -79,6 +79,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "snap",                      @import("command/move.zig").snap },
         .{ "spawn",                     @import("command/spawn.zig").spawn },
         .{ "spawn-tagmask",             @import("command/tags.zig").spawnTagmask },
+        .{ "global-spawn-tagmask",      @import("command/tags.zig").spawnTagmaskGlobal },
         .{ "swap",                      @import("command/swap.zig").swap},
         .{ "toggle-float",              @import("command/toggle_float.zig").toggleFloat },
         .{ "toggle-focused-tags",       @import("command/tags.zig").toggleFocusedTags },

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -39,14 +39,24 @@ pub fn setFocusedTags(
     }
 }
 
-/// Set the spawn tagmask
-pub fn spawnTagmask(
+/// Set the global spawn tagmask
+pub fn spawnTagmaskGlobal(
     _: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
 ) Error!void {
     const tags = try parseTags(args, out);
     server.config.spawn_tagmask = tags;
+}
+
+/// Set the spawn tagmask
+pub fn spawnTagmask(
+    seat: *Seat,
+    args: []const [:0]const u8,
+    out: *?[]const u8,
+) Error!void {
+    const tags = try parseTags(args, out);
+    seat.focused_output.spawn_tagmask = tags;
 }
 
 /// Set the tags of the focused view.

--- a/river/command/tags.zig
+++ b/river/command/tags.zig
@@ -41,12 +41,12 @@ pub fn setFocusedTags(
 
 /// Set the spawn tagmask
 pub fn spawnTagmask(
-    seat: *Seat,
+    _: *Seat,
     args: []const [:0]const u8,
     out: *?[]const u8,
 ) Error!void {
     const tags = try parseTags(args, out);
-    seat.focused_output.spawn_tagmask = tags;
+    server.config.spawn_tagmask = tags;
 }
 
 /// Set the tags of the focused view.


### PR DESCRIPTION
Not quite complete yet, but wanted to post it so people can comment about their use-case and see what makes the most sense.

Currently per-output spawn-tagmask have a few problems. Setting it for an particular output is difficult since it involves focus. The tagmask will be lost if the output is gone (it went to sleep, etc).

Having just an global tagmask would solve these problems, it should not affect any use-cases afaik, but it certainly might break some people's config/use-case that I'm not aware of.
Having both global and per-output tagmask won't break existing setups but the problems will still exist and can be confusing for users to have two tagmasks.