### PR TITLE
support single_pixel_buffer_v1 protocol

### DIFF
--- a/river/Server.zig
+++ b/river/Server.zig
@@ -137,6 +137,7 @@ pub fn init(self: *Self) !void {
     _ = try wlr.ExportDmabufManagerV1.create(self.wl_server);
     _ = try wlr.GammaControlManagerV1.create(self.wl_server);
     _ = try wlr.ScreencopyManagerV1.create(self.wl_server);
+    _ = try wlr.SinglePixelBufferManagerV1.create(self.wl_server);
     _ = try wlr.Viewporter.create(self.wl_server);
 }
 


### PR DESCRIPTION
Depends on swaywm/zig-wlroots/pull/59.