### PR TITLE
touch: support drag and drop

### DIFF
--- a/river/Root.zig
+++ b/river/Root.zig
@@ -56,8 +56,6 @@ outputs: std.TailQueue(Output) = .{},
 /// It is not advertised to clients.
 noop_output: Output = undefined,
 
-drag_icons: std.SinglyLinkedList(DragIcon) = .{},
-
 /// This list stores all "override redirect" Xwayland windows. This needs to be in root
 /// since X is like the wild west and who knows where these things will place themselves.
 xwayland_override_redirect_views: if (build_options.xwayland)


### PR DESCRIPTION
Closes #634

Any help testing this PR by people with touchscreens would be much appreciated and is require before this can be merged as I don't have a test system with a touch screen currently.

To test, the `weston-dnd` client might be useful. Alternatively, dragging firefox tabs by touch should work now in theory and show a drag icon just as dragging them with the pointer currently does.