### PR TITLE
river_control: mark callback events as destructors

### DIFF
--- a/protocol/river-control-unstable-v1.xml
+++ b/protocol/river-control-unstable-v1.xml
@@ -63,7 +63,7 @@
       by the compositor after one of the events is sent.
     </description>
 
-    <event name="success">
+    <event name="success" type="destructor">
       <description summary="command successful">
         Sent when the command has been successfully received and executed by
         the compositor. Some commands may produce output, in which case the
@@ -72,7 +72,7 @@
       <arg name="output" type="string" summary="the output of the command"/>
     </event>
 
-    <event name="failure">
+    <event name="failure" type="destructor">
       <description summary="command failed">
         Sent when the command could not be carried out. This could be due to
         sending a non-existent command, no command, not enough arguments, too

--- a/river/Control.zig
+++ b/river/Control.zig
@@ -116,7 +116,7 @@ fn handleRequest(control: *zriver.ControlV1, request: zriver.ControlV1.Request, 
                     else => command.errToMsg(err),
                 };
                 defer if (err == command.Error.Other) util.gpa.free(failure_message);
-                callback.sendFailure(failure_message);
+                callback.destroySendFailure(failure_message);
                 return;
             };
 
@@ -128,7 +128,7 @@ fn handleRequest(control: *zriver.ControlV1, request: zriver.ControlV1.Request, 
             else
                 "";
             defer if (out != null) util.gpa.free(success_message);
-            callback.sendSuccess(success_message);
+            callback.destroySendSuccess(success_message);
         },
     }
 }


### PR DESCRIPTION
I suppose these kind of changes require a version bump, but since callback has no requests, this change should not break anything. Please let me know if my assumption is wrong.