### PR TITLE
Update riverctl.1.scd

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -342,6 +342,12 @@ A complete list may be found in _/usr/include/linux/input-event-codes.h_
 	combinations configured through the options argument (e.g. -options
 	"grp:ctrl_space_toggle"). See *xkeyboard-config*(7) for possible values and
 	more information.
+	
+Note: tested on Arch Linux, if the above and other environmental variables fail to
+change the keyboard layout, try adding ```export XKB_DEFAULT_LAYOUT=var``` to 
+~/.bash_profile per user. For example, changing to dvorak keyboard layout is
+```export XKB_DEFAULT_LAYOUT=us"(dvorak)"```. This may work on other operating
+systems but I have tested this only on Arch Linux.
 
 *keyboard-group-create* _group_name_
 	Create a keyboard group. A keyboard group collects multiple keyboards in


### PR DESCRIPTION
The proposed note I think is very much needed. I tried changing the keyboard layout using so many methods but .bash_profile was the only one that had actually changed the layout. for more info, I have the xwayland flag on during river install. This Arch install is very recent and the hardware is from the thinkpad E15 12th gen. Just encase any of that info useful. Feel free to change the wording, I just want .bash_profile mentioned as an alternative for others who have found changing keyboard layout to be seemingly impossible.