### PR TITLE
river-status: add keyboard_layout event

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -125,7 +125,7 @@ pub fn build(b: *Build) !void {
     scanner.generate("wp_cursor_shape_manager_v1", 1);
 
     scanner.generate("zriver_control_v1", 1);
-    scanner.generate("zriver_status_manager_v1", 4);
+    scanner.generate("zriver_status_manager_v1", 5);
     scanner.generate("river_layout_manager_v3", 2);
 
     scanner.generate("zwlr_layer_shell_v1", 4);

--- a/protocol/river-status-unstable-v1.xml
+++ b/protocol/river-status-unstable-v1.xml
@@ -16,7 +16,7 @@
     OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
   </copyright>
 
-  <interface name="zriver_status_manager_v1" version="4">
+  <interface name="zriver_status_manager_v1" version="5">
     <description summary="manage river status objects">
       A global factory for objects that receive status information specific
       to river. It could be used to implement, for example, a status bar.
@@ -47,7 +47,7 @@
     </request>
   </interface>
 
-  <interface name="zriver_output_status_v1" version="4">
+  <interface name="zriver_output_status_v1" version="5">
     <description summary="track output tags and focus">
       This interface allows clients to receive information about the current
       windowing state of an output.
@@ -100,7 +100,7 @@
     </event>
   </interface>
 
-  <interface name="zriver_seat_status_v1" version="3">
+  <interface name="zriver_seat_status_v1" version="5">
     <description summary="track seat focus">
       This interface allows clients to receive information about the current
       focus of a seat. Note that (un)focused_output events will only be sent
@@ -143,6 +143,25 @@
         is entered (e.g. with riverctl enter-mode foobar).
       </description>
       <arg name="name" type="string" summary="name of the mode"/>
+    </event>
+
+    <event name="keyboard_layout" since="5">
+      <description summary="the name of currently active keyboard layout">
+        Sent whenever the name of active keyboard layout changes. Either this
+        or keyboard_layout_clear event is sent on binding the interface for
+        each keyboard.
+      </description>
+      <arg name="device" type="string" summary="the identifier of keyboard device"/>
+      <arg name="layout" type="string" summary="name of the layout"/>
+    </event>
+
+    <event name="keyboard_layout_clear" since="5">
+      <description summary="the name of currently active keyboard layout">
+        Sent whenever the name of active keyboard layout becomes unavailable.
+        Either this or keyboard_layout event is sent on binding the interface
+        for each keyboard.
+      </description>
+      <arg name="device" type="string" summary="the identifier of keyboard device"/>
     </event>
   </interface>
 </protocol>

--- a/river/SeatStatus.zig
+++ b/river/SeatStatus.zig
@@ -27,6 +27,8 @@ const util = @import("util.zig");
 const Seat = @import("Seat.zig");
 const Output = @import("Output.zig");
 const View = @import("View.zig");
+const Keyboard = @import("Keyboard.zig");
+const InputDevice = @import("InputDevice.zig");
 
 seat: *Seat,
 seat_status_v1: *zriver.SeatStatusV1,
@@ -40,6 +42,13 @@ pub fn init(seat_status: *SeatStatus, seat: *Seat, seat_status_v1: *zriver.SeatS
     seat_status.sendMode(server.config.modes.items[seat.mode_id].name);
     if (seat.focused_output) |output| seat_status.sendOutput(output, .focused);
     seat_status.sendFocusedView();
+
+    var it = server.input_manager.devices.iterator(.forward);
+    while (it.next()) |device| {
+        if (device.wlr_device.type != .keyboard) continue;
+        const wlr_keyboard = device.wlr_device.toKeyboard();
+        seat_status.sendKeyboardLayout(device, Keyboard.getActiveLayoutName(wlr_keyboard));
+    }
 }
 
 fn handleRequest(seat_status_v1: *zriver.SeatStatusV1, request: zriver.SeatStatusV1.Request, _: *SeatStatus) void {
@@ -76,5 +85,15 @@ pub fn sendFocusedView(seat_status: SeatStatus) void {
 pub fn sendMode(seat_status: SeatStatus, mode: [*:0]const u8) void {
     if (seat_status.seat_status_v1.getVersion() >= 3) {
         seat_status.seat_status_v1.sendMode(mode);
+    }
+}
+
+pub fn sendKeyboardLayout(seat_status: SeatStatus, device: *InputDevice, opt_layout: ?[*:0]const u8) void {
+    if (seat_status.seat_status_v1.getVersion() < 5) return;
+
+    if (opt_layout) |layout| {
+        seat_status.seat_status_v1.sendKeyboardLayout(device.identifier, layout);
+    } else {
+        seat_status.seat_status_v1.sendKeyboardLayoutClear(device.identifier);
     }
 }

--- a/river/StatusManager.zig
+++ b/river/StatusManager.zig
@@ -39,7 +39,7 @@ server_destroy: wl.Listener(*wl.Server) = wl.Listener(*wl.Server).init(handleSer
 
 pub fn init(status_manager: *StatusManager) !void {
     status_manager.* = .{
-        .global = try wl.Global.create(server.wl_server, zriver.StatusManagerV1, 4, ?*anyopaque, null, bind),
+        .global = try wl.Global.create(server.wl_server, zriver.StatusManagerV1, 5, ?*anyopaque, null, bind),
     };
 
     server.wl_server.addDestroyListener(&status_manager.server_destroy);

--- a/river/command/keyboard.zig
+++ b/river/command/keyboard.zig
@@ -104,5 +104,7 @@ fn applyLayout(new_keymap: *xkb.Keymap) void {
         // wlroots will log an error if this fails and there's unfortunately
         // nothing we can really do in the case of failure.
         _ = wlr_keyboard.setKeymap(new_keymap);
+
+        device.notifyKbdLayoutChanged();
     }
 }


### PR DESCRIPTION
I'm new to zig and server-side wayland, so please let me know if if there are better ways to do certain things.

`sway` was used as a reference.

- Simple test client: https://github.com/MaxVerevkin/river-kbd-layout-watcher
- Status bar integration: https://github.com/MaxVerevkin/i3status-rust/tree/river-kbd