### PR TITLE
river_seat_status 3 -> 4

### DIFF
--- a/protocol/river-status-unstable-v1.xml
+++ b/protocol/river-status-unstable-v1.xml
@@ -100,7 +100,7 @@
     </event>
   </interface>
 
-  <interface name="zriver_seat_status_v1" version="3">
+  <interface name="zriver_seat_status_v1" version="4">
     <description summary="track seat focus">
       This interface allows clients to receive information about the current
       focus of a seat. Note that (un)focused_output events will only be sent


### PR DESCRIPTION
Perhaps a check could be added to zig-wayland scanner to prevent this kind of errors?