### PR TITLE
ci: Use meson setup command

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -28,13 +28,13 @@ tasks:
   - install_deps: |
       cd wayland
       git checkout 1.21.0
-      meson build -Ddocumentation=false -Dtests=false --prefix /usr
+      meson setup build -Ddocumentation=false -Dtests=false --prefix /usr
       sudo ninja -C build install
       cd ..
 
       cd wlroots
       git checkout 0.16.0
-      meson build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
+      meson setup build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
             -Dwerror=false -Db_ndebug=false -Dxcb-errors=disabled --prefix /usr
       sudo ninja -C build/ install
       cd ..

--- a/.builds/archlinux.yml
+++ b/.builds/archlinux.yml
@@ -26,13 +26,13 @@ tasks:
   - install_deps: |
       cd wayland
       git checkout 1.21.0
-      meson build -Ddocumentation=false -Dtests=false --prefix /usr
+      meson setup build -Ddocumentation=false -Dtests=false --prefix /usr
       sudo ninja -C build install
       cd ..
 
       cd wlroots
       git checkout 0.16.0
-      meson build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
+      meson setup build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
             -Dwerror=false -Db_ndebug=false --prefix /usr
       sudo ninja -C build/ install
       cd ..

--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -30,13 +30,13 @@ tasks:
   - install_deps: |
       cd wayland
       git checkout 1.21.0
-      meson build -Ddocumentation=false -Dtests=false --prefix /usr
+      meson setup build -Ddocumentation=false -Dtests=false --prefix /usr
       sudo ninja -C build install
       cd ..
 
       cd wlroots
       git checkout 0.16.0
-      meson build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
+      meson setup build --auto-features=enabled -Drenderers=gles2 -Dexamples=false \
             -Dwerror=false -Db_ndebug=false --prefix /usr
       sudo ninja -C build/ install
       cd ..


### PR DESCRIPTION
Using `meson build` without `setup` have been deprecated, fix warning message:
  'WARNING: Running the setup command as `meson [options]` instead of
  `meson setup [options]` is ambiguous and deprecated.