### PR TITLE
Cursor: fix incorrect lock manager state assertion

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -367,7 +367,7 @@ fn updateKeyboardFocus(self: Self, result: SurfaceAtResult) void {
             self.seat.setFocusRaw(.{ .lock_surface = lock_surface });
         },
         .xwayland_override_redirect => |override_redirect| {
-            assert(server.lock_manager.state != .unlocked);
+            assert(server.lock_manager.state == .unlocked);
             override_redirect.focusIfDesired();
         },
     }


### PR DESCRIPTION
This caused river to panic upon focusing an OR surface via the cursor (e.g. clicking on an OR menu).