### PR TITLE
Apply new adaptive sync value from wlr-output-management

### DIFF
--- a/river/Root.zig
+++ b/river/Root.zig
@@ -461,6 +461,7 @@ fn processOutputConfig(
             }
             wlr_output.setScale(head.state.scale);
             wlr_output.setTransform(head.state.transform);
+            wlr_output.enableAdaptiveSync(head.state.adaptive_sync_enabled);
 
             switch (action) {
                 .test_only => {


### PR DESCRIPTION
Apply changes to adaptive sync from wlr-output-management clients.

See similar sway PR: https://github.com/swaywm/sway/pull/7395

Test cases with [way-displays](https://github.com/alex-courtis/way-displays) 1.7.1:
supported display:
```
I [13:26:23] DP-1 Changing:
I [13:26:23]   from:
I [13:26:23]     scale:    1.000
I [13:26:23]     position: 0,0
I [13:26:23]     mode:     3840x2160@144Hz (144,000mHz)
I [13:26:23]     VRR:      off
I [13:26:23]   to:
I [13:26:23]     VRR:      on
I [13:26:23]
I [13:26:23] Changes successful
```

unsupported display:
```
I [13:40:30] eDP-1 Changing:
I [13:40:30]   from:
I [13:40:30]     scale:    1.000
I [13:40:30]     position: 0,0
I [13:40:30]     mode:     2560x1440@60Hz (59,998mHz) (preferred)
I [13:40:30]     VRR:      off
I [13:40:30]   to:
I [13:40:30]     VRR:      on
I [13:40:30]
I [13:40:30] eDP-1: Cannot enable VRR, display or compositor may not support it.
```