### PR TITLE
Config: Asterisk globing for csd and float filters

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -31,6 +31,8 @@ over the Wayland protocol.
 *csd-filter-add* *app-id*|*title* _pattern_
 	Add _pattern_ to the CSD filter list. Views with this _pattern_ are told to
 	use client side decoration instead of the default server side decoration.
+	If first or last caracter in _pattern_ is asterisk, _pattern_ is matched
+	against end or beginning of view respectively.
 	Note that this affects new views as well as already existing ones. Title
 	updates are not taken into account.
 
@@ -42,9 +44,10 @@ over the Wayland protocol.
 	Exit the compositor, terminating the Wayland session.
 
 *float-filter-add* *app-id*|*title* _pattern_
-	Add a pattern to the float filter list. Note that this affects only new
-	views, not already existing ones. Title updates are also not taken into
-	account.
+	Add a pattern to the float filter list. If first or last caracter in _pattern_
+	is asterisk, _pattern_ is matched against end or beginning of view respectively.
+	Note that this affects only new views, not already existing ones. Title updates
+	are also not taken into account.
 
 *float-filter-remove* *app-id*|*title* _pattern_
 	Remove an app-id or title from the float filter list. Note that this

--- a/river/command/filter.zig
+++ b/river/command/filter.zig
@@ -24,6 +24,7 @@ const util = @import("../util.zig");
 const View = @import("../View.zig");
 const Error = @import("../command.zig").Error;
 const Seat = @import("../Seat.zig");
+const Config = @import("../Config.zig");
 
 const FilterKind = enum {
     @"app-id",
@@ -143,5 +144,5 @@ fn viewMatchesPattern(kind: FilterKind, pattern: []const u8, view: *View) bool {
         .title => mem.span(view.getTitle()),
     } orelse return false;
 
-    return mem.eql(u8, pattern, p);
+    return Config.itemMatchesPattern(pattern, p);
 }


### PR DESCRIPTION
Filter pattern starting with asterisk will match all titles/app-ids, that ends with filter pattern, while filter with astersik at the end will match beginning of test string.

This implements #703, however I'm not sure about a few points:

* Currently, river crashes if there is filter containig single asterisk and new window spawns. Is it possible, that I'm missing something obvious about zig? (Discalimer: I only have two day experince in zig) Or, maybe riverctl should error out, when passing single asterisk as filter?

* There are few lines of code in `river/command/filter.zig` in `csdFilterUpdateViews`. I guess it will need some adjustments.