### PR TITLE
Cursor: improve interaction of move/resize with the transaction system

### DIFF
--- a/river/Root.zig
+++ b/river/Root.zig
@@ -512,6 +512,8 @@ pub fn applyPending(root: *Self) void {
                     }
                 },
             }
+
+            cursor.inflight_mode = cursor.mode;
         }
     }
 

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -493,6 +493,28 @@ pub fn applyPending(root: *Self) void {
         }
     }
 
+    {
+        var it = server.input_manager.seats.first;
+        while (it) |node| : (it = node.next) {
+            const cursor = &node.data.cursor;
+
+            switch (cursor.mode) {
+                .passthrough, .down => {},
+                inline .move, .resize => |data| {
+                    if (data.view.inflight.output == null or
+                        data.view.inflight.tags & data.view.inflight.output.?.inflight.tags == 0 or
+                        (!data.view.inflight.float and data.view.inflight.output.?.layout != null) or
+                        data.view.inflight.fullscreen)
+                    {
+                        cursor.mode = .passthrough;
+                        data.view.pending.resizing = false;
+                        data.view.inflight.resizing = false;
+                    }
+                },
+            }
+        }
+    }
+
     if (root.inflight_layout_demands == 0) {
         root.sendConfigures();
     }

--- a/river/View.zig
+++ b/river/View.zig
@@ -297,17 +297,22 @@ pub fn updateCurrent(view: *Self) void {
             }
             xdg_toplevel.configure_state = .idle;
         },
-        .xwayland_view => |xwayland_view| {
-            if (view.inflight.resizing) {
-                view.resizeUpdatePosition(
-                    xwayland_view.xwayland_surface.width,
-                    xwayland_view.xwayland_surface.height,
-                );
+        // TODO(zig): this capture does not need to be mutable and the if (build_options.xwayland)
+        // is unnecessary. However, zig 0.10.0 is buggy and these work around a bug. They are both
+        // fixed in zig 0.10.1 and newer but we currently rely on 0.10.0 for FreeBSD CI.
+        .xwayland_view => |*xwayland_view| {
+            if (build_options.xwayland) {
+                if (view.inflight.resizing) {
+                    view.resizeUpdatePosition(
+                        xwayland_view.xwayland_surface.width,
+                        xwayland_view.xwayland_surface.height,
+                    );
+                }
+                view.inflight.box.width = xwayland_view.xwayland_surface.width;
+                view.inflight.box.height = xwayland_view.xwayland_surface.height;
+                view.pending.box.width = xwayland_view.xwayland_surface.width;
+                view.pending.box.height = xwayland_view.xwayland_surface.height;
             }
-            view.inflight.box.width = xwayland_view.xwayland_surface.width;
-            view.inflight.box.height = xwayland_view.xwayland_surface.height;
-            view.pending.box.width = xwayland_view.xwayland_surface.width;
-            view.pending.box.height = xwayland_view.xwayland_surface.height;
         },
         .none => {},
     }


### PR DESCRIPTION
Fixes #804

TODO: 
- [x] Fix build with zig 0.10.0, it's crashing but 0.10.1 works fine. I wouldn't bother but the freebsd CI relies on 0.10.0 currently.
- [x] Try and clean things up some more, the new code isn't terribly pretty although it seems to work well.
- [ ] ~~Consider centering on the vertical axis while resized from only the left or right edge (and vice versa for the horizontal axis). This would feel nicer for mpv if it's not too complex.~~ this turned out not to work well due to rounding issues, at least with my simple implementation.