### PR TITLE
Implement -current-tags for send-to-output

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -50,9 +50,12 @@ over the Wayland protocol.
 	Snap the focused view to the specified screen edge. The view will
 	be set to floating.
 
-*send-to-output* *next*|*previous*|*up*|*right*|*down*|*left*|_name_
+*send-to-output* [*-current-tags*] *next*|*previous*|*up*|*right*|*down*|*left*|_name_
 	Send the focused view to the next or previous output, the closest
 	output in any direction or to an output by name.
+
+	- *-current-tags*: Assign the currently focused tags of the destination
+	  output to the view.
 
 *spawn* _shell_command_
 	Run _shell_command_ using `/bin/sh -c _shell_command_`. Note that


### PR DESCRIPTION
As proposed on IRC, this implements the option to pass `-current-tags` to the `send-to-output` command. The flag will cause views to be tagged with the views of the destination when send to a different output. 

Visually, this results in the view always staying visible on output move.