### PR TITLE
Rework move/resize handling

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -79,6 +79,9 @@ const Mode = union(enum) {
         delta_x: f64 = 0,
         delta_y: f64 = 0,
 
+        fixup_x: i32 = 0,
+        fixup_y: i32 = 0,
+
         /// Resize edges, maximum of 2 are set and they may not be opposing edges.
         edges: wlr.Edges,
         /// Offset from the left or right edge

--- a/river/LayoutDemand.zig
+++ b/river/LayoutDemand.zig
@@ -133,20 +133,14 @@ pub fn apply(self: *Self, layout: *Layout) void {
             // Here we apply the offset to align the coords with the origin of the
             // usable area and shrink the dimensions to accommodate the border size.
             const border_width = if (view.inflight.ssd) server.config.border_width else 0;
-            view.inflight.box = .{
+            view.inflight_box = .{
                 .x = proposed.x + output.usable_box.x + border_width,
                 .y = proposed.y + output.usable_box.y + border_width,
                 .width = proposed.width - 2 * border_width,
                 .height = proposed.height - 2 * border_width,
             };
 
-            view.applyConstraints(&view.inflight.box);
-
-            // State flowing "backwards" like this is pretty ugly, but I don't
-            // see a better way to sync this up right now.
-            if (!view.pending.float and !view.pending.fullscreen) {
-                view.pending.box = view.inflight.box;
-            }
+            view.applyConstraints(&view.inflight_box, view.inflight);
 
             i += 1;
         }

--- a/river/View.zig
+++ b/river/View.zig
@@ -252,8 +252,11 @@ pub fn resizeUpdatePosition(view: *Self, width: i32, height: i32) void {
     const unconstrained_x = box.x;
     const unconstrained_y = box.y;
 
-    box.x = math.clamp(box.x, border_width, output_width - border_width - width);
-    box.y = math.clamp(box.y, border_width, output_height - border_width - height);
+    box.x = math.min(box.x, output_width - border_width - width);
+    box.x = math.max(box.x, border_width);
+
+    box.y = math.min(box.y, output_height - border_width - height);
+    box.y = math.max(box.y, border_width);
 
     data.fixup_x = unconstrained_x -| box.x;
     data.fixup_y = unconstrained_y -| box.y;


### PR DESCRIPTION
This branch replaces the absolute x/y/width/height in the pending state of views with accumulated deltas.

It also changes the behavior of resizing to always allow growing a window even if against the edge of the output. This behavior or something like it is, as far as I can tell, necessary to handle clients (such as mpv) responding to the resize with a size larger than what we asked for in one dimension. 

For example resizing mpv along only the x-axis causes it to grow along the y-axis as well to maintain aspect ratio. The xdg-shell protocol states:

> The window geometry specified in the configure event is a maximum; the client cannot resize beyond it. Clients that have aspect ratio or cell sizing configuration can use a smaller size, however.

I'm not sure how else we should expect clients that wish to maintain an aspect ratio to grow in size however. The behavior of mpv in this case seems like the only reasonable thing clients can do and I don't know of any compositor that sends an error in this case.

The current state of this branch is pretty much a proof of concept. The code is really ugly and needs cleanup before it can be merged.

The only known bug is when mpv is paused and I try to resize it vertically, which it refuses. It seems that a transaction timeout in this case (or perhaps in general?) makes it possible for the window to get moved vertically instead of nothing happening. This needs more investigation as well as more careful consideration of how this new approach interacts with transaction timeouts in general.

Any testing would be appreciated, I have yet to test this heavily on slower machines.

Fixes #812