### PR TITLE
editorconfig: fix typo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-charset = utf8
+charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#charset seems to suggest that the value should be named `utf-8` and Neovim with `editorconfig` enabled complained for me as-is.