### PR TITLE
ext-foreign-toplevel-info-v1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -95,6 +95,7 @@ pub fn build(b: *zbs.Builder) !void {
     scanner.addProtocolPath("protocol/river-control-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-status-unstable-v1.xml");
     scanner.addProtocolPath("protocol/river-layout-v3.xml");
+    scanner.addProtocolPath("protocol/ext-foreign-toplevel-list-v1");
     scanner.addProtocolPath("protocol/wlr-layer-shell-unstable-v1.xml");
     scanner.addProtocolPath("protocol/wlr-output-power-management-unstable-v1.xml");
 
@@ -112,6 +113,7 @@ pub fn build(b: *zbs.Builder) !void {
     scanner.generate("zwp_pointer_constraints_v1", 1);
     scanner.generate("zxdg_decoration_manager_v1", 1);
     scanner.generate("ext_session_lock_manager_v1", 1);
+    scanner.generate("ext_foreign_toplevel_list_v1", 1);
 
     scanner.generate("zriver_control_v1", 1);
     scanner.generate("zriver_status_manager_v1", 4);

--- a/protocol/ext-foreign-toplevel-list-v1
+++ b/protocol/ext-foreign-toplevel-list-v1
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_foreign_toplevel_list_v1">
+  <copyright>
+    Copyright © 2018 Ilia Bozhinov
+    Copyright © 2020 Isaac Freund
+    Copyright © 2022 wb9688
+    Copyright © 2023 i509VCB
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="list toplevels">
+    The purpose of this protocol is to provide protocol object handles for
+    toplevels, possibly originating from another client.
+
+    This protocol is intentionally minimalistic and expects additional
+    functionality (e.g. creating a screencopy source from a toplevel handle,
+    getting information about the state of the toplevel) to be implemented
+    in extension protocols.
+
+    The compositor may choose to restrict this protocol to a special client
+    launched by the compositor itself or expose it to all clients,
+    this is compositor policy.
+
+    The key words "must", "must not", "required", "shall", "shall not",
+    "should", "should not", "recommended",  "may", and "optional" in this
+    document are to be interpreted as described in IETF RFC 2119.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_foreign_toplevel_list_v1" version="1">
+    <description summary="list toplevels">
+      A toplevel is defined as a surface with a role similar to xdg_toplevel.
+      XWayland surfaces may be treated like toplevels in this protocol.
+
+      After a client binds the ext_foreign_toplevel_list_v1, each mapped
+      toplevel window will be sent using the ext_foreign_toplevel_list_v1.toplevel
+      event.
+
+      Clients which only care about the current state can perform a roundtrip after
+      binding this global.
+
+      For each instance of ext_foreign_toplevel_list_v1, the compositor must
+      create a new ext_foreign_toplevel_handle_v1 object for each mapped toplevel.
+
+      If a compositor implementation sends the ext_foreign_toplevel_list_v1.finished
+      event after the global is bound, the compositor must not send any
+      ext_foreign_toplevel_list_v1.toplevel events.
+    </description>
+
+    <event name="toplevel">
+      <description summary="a toplevel has been created">
+        This event is emitted whenever a new toplevel window is created. It is
+        emitted for all toplevels, regardless of the app that has created them.
+
+        All initial properties of the toplevel (identifier, title, app_id) will be sent
+        immediately after this event using the corresponding events for
+        ext_foreign_toplevel_handle_v1. The compositor will use the
+        ext_foreign_toplevel_handle_v1.done event to indicate when all data has
+        been sent.
+      </description>
+      <arg name="toplevel" type="new_id" interface="ext_foreign_toplevel_handle_v1"/>
+    </event>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the toplevel manager">
+        This event indicates that the compositor is done sending events
+        to this object. The client should should destroy the object.
+        See ext_foreign_toplevel_list_v1.destroy for more information.
+
+        The compositor must not send any more toplevel events after this event.
+      </description>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        This request indicates that the client no longer wishes to receive
+        events for new toplevels.
+
+        The Wayland protocol is asynchronous, meaning the compositor may send
+        further toplevel events until the stop request is processed.
+        The client should wait for a ext_foreign_toplevel_list_v1.finished
+        event before destroying this object.
+      </description>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_foreign_toplevel_list_v1 object">
+        This request should be called either when the client will no longer
+        use the ext_foreign_toplevel_list_v1 or after the finished event
+        has been received to allow destruction of the object.
+
+        If a client wishes to destroy this object it should send a
+        ext_foreign_toplevel_list_v1.stop request and wait for a ext_foreign_toplevel_list_v1.finished
+        event, then destroy the handles and then this object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_foreign_toplevel_handle_v1" version="1">
+    <description summary="a mapped toplevel">
+      A ext_foreign_toplevel_handle_v1 object represents a mapped toplevel
+      window. A single app may have multiple mapped toplevels.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ext_foreign_toplevel_handle_v1 object">
+        This request should be used when the client will no longer use the handle
+        or after the closed event has been received to allow destruction of the
+        object.
+
+        When a handle is destroyed, a new handle may not be created by the server
+        until the toplevel is unmapped and then remapped. Destroying a toplevel handle
+        is not recommended unless the client is cleaning up child objects
+        before destroying the ext_foreign_toplevel_list_v1 object, the toplevel
+        was closed or the toplevel handle will not be used in the future.
+
+        Other protocols which extend the ext_foreign_toplevel_handle_v1
+        interface should require destructors for extension interfaces be
+        called before allowing the toplevel handle to be destroyed.
+      </description>
+    </request>
+
+    <event name="closed">
+      <description summary="the toplevel has been closed">
+        The server will emit no further events on the ext_foreign_toplevel_handle_v1
+        after this event. Any requests received aside from the destroy request must
+        be ignored. Upon receiving this event, the client should destroy the handle.
+
+        Other protocols which extend the ext_foreign_toplevel_handle_v1
+        interface must also ignore requests other than destructors.
+      </description>
+    </event>
+
+    <event name="done">
+      <description summary="all information about the toplevel has been sent">
+        This event is sent after all changes in the toplevel state have
+        been sent.
+
+        This allows changes to the ext_foreign_toplevel_handle_v1 properties
+        to be atomically applied. Other protocols which extend the
+        ext_foreign_toplevel_handle_v1 interface may use this event to also
+        atomically apply any pending state.
+
+        This event must not be sent after the ext_foreign_toplevel_handle_v1.closed
+        event.
+      </description>
+    </event>
+
+    <event name="title">
+      <description summary="title change">
+        The title of the toplevel has changed.
+
+        The configured state must not be applied immediately. See
+        ext_foreign_toplevel_handle_v1.done for details.
+      </description>
+      <arg name="title" type="string"/>
+    </event>
+
+    <event name="app_id">
+      <description summary="app_id change">
+        The app id of the toplevel has changed.
+
+        The configured state must not be applied immediately. See
+        ext_foreign_toplevel_handle_v1.done for details.
+      </description>
+      <arg name="app_id" type="string"/>
+    </event>
+
+    <event name="identifier">
+      <description summary="a stable identifier for a toplevel">
+        This identifier is used to check if two or more toplevel handles belong
+        to the same toplevel.
+
+        The identifier is useful for command line tools or privileged clients
+        which may need to reference an exact toplevel across processes or
+        instances of the ext_foreign_toplevel_list_v1 global.
+
+        The compositor must only send this event when the handle is created.
+
+        The identifier must be unique per toplevel and it's handles. Two different
+        toplevels must not have the same identifier. The identifier is only valid
+        as long as the toplevel is mapped. If the toplevel is unmapped the identifier
+        must not be reused. An identifier must not be reused by the compositor to
+        ensure there are no races when sharing identifiers between processes.
+
+        An identifier is a string that contains up to 32 printable ASCII bytes.
+        An identifier must not be an empty string. It is recommended that a
+        compositor includes an opaque generation value in identifiers. How the
+        generation value is used when generating the identifier is implementation
+        dependent.
+      </description>
+      <arg name="identifier" type="string"/>
+    </event>
+  </interface>
+</protocol>

--- a/river/ForeignToplevelListHandle.zig
+++ b/river/ForeignToplevelListHandle.zig
@@ -1,0 +1,22 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2023 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const ForeignToplevelListHandle = @This();
+
+const std = @import("std");
+const View = @import("View.zig");
+
+const server = &@import("main.zig").server;

--- a/river/ForeignToplevelListManager.zig
+++ b/river/ForeignToplevelListManager.zig
@@ -45,7 +45,7 @@ fn bind(client: *wl.Client, self: *Self, version: u32, id: u32) void {
         log.err("out of memory", .{});
         return;
     };
-    foreign_toplevel_list.setHandler(?*anyopaque, handleRequest, null, null);
+    foreign_toplevel_list.setHandler(*Self, handleRequest, handleDestroy, self);
     self.instances.append(foreign_toplevel_list);
 
     var it = server.root.views.iterator(.forward);
@@ -67,12 +67,19 @@ fn bind(client: *wl.Client, self: *Self, version: u32, id: u32) void {
 fn handleRequest(
     foreign_toplevel_list: *ext.ForeignToplevelListV1,
     request: ext.ForeignToplevelListV1.Request,
-    _: ?*anyopaque,
+    _: *Self,
 ) void {
     switch (request) {
         .destroy => foreign_toplevel_list.destroy(),
         .stop => {},
     }
+}
+
+fn handleDestroy(
+    foreign_toplevel_list: *ext.ForeignToplevelListV1,
+    _: *Self,
+) void {
+    foreign_toplevel_list.getLink().remove();
 }
 
 fn handleServerDestroy(listener: *wl.Listener(*wl.Server), _: *wl.Server) void {

--- a/river/ForeignToplevelListManager.zig
+++ b/river/ForeignToplevelListManager.zig
@@ -1,0 +1,85 @@
+// This file is part of river, a dynamic tiling wayland compositor.
+//
+// Copyright 2023 The River Developers
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+const Self = @This();
+
+const std = @import("std");
+const wlr = @import("wlroots");
+const wayland = @import("wayland");
+const wl = wayland.server.wl;
+const ext = wayland.server.ext;
+const log = std.log.scoped(.foreign_toplevel_list);
+
+const server = &@import("main.zig").server;
+const Server = @import("Server.zig");
+
+global: *wl.Global,
+instances: wl.list.Head(ext.ForeignToplevelListV1, null) = undefined,
+server_destroy: wl.Listener(*wl.Server) = wl.Listener(*wl.Server).init(handleServerDestroy),
+
+pub fn init(self: *Self) !void {
+    self.* = .{
+        .global = try wl.Global.create(server.wl_server, ext.ForeignToplevelListV1, 1, *Self, self, bind),
+    };
+    self.instances.init();
+    server.wl_server.addDestroyListener(&self.server_destroy);
+}
+
+fn bind(client: *wl.Client, self: *Self, version: u32, id: u32) void {
+    // TODO XXX go over all views
+    const foreign_toplevel_list = ext.ForeignToplevelListV1.create(client, version, id) catch {
+        client.postNoMemory();
+        log.err("out of memory", .{});
+        return;
+    };
+    foreign_toplevel_list.setHandler(?*anyopaque, handleRequest, null, null);
+    self.instances.append(foreign_toplevel_list);
+
+    var it = server.root.views.iterator(.forward);
+    while (it.next()) |view| {
+        const handle = ext.ForeignToplevelHandleV1.create(
+            client,
+            version,
+            0,
+        ) catch {
+            client.postNoMemory();
+            log.err("out of memory", .{});
+            return;
+        };
+        foreign_toplevel_list.sendToplevel(handle);
+        view.addForeignToplevelListHandle(handle);
+    }
+}
+
+fn handleRequest(
+    foreign_toplevel_list: *ext.ForeignToplevelListV1,
+    request: ext.ForeignToplevelListV1.Request,
+    _: ?*anyopaque,
+) void {
+    switch (request) {
+        .destroy => foreign_toplevel_list.destroy(),
+        .stop => {},
+    }
+}
+
+fn handleServerDestroy(listener: *wl.Listener(*wl.Server), _: *wl.Server) void {
+    const self = @fieldParentPtr(Self, "server_destroy", listener);
+    var it = self.instances.iterator(.forward);
+    while (it.next()) |resource| {
+        resource.destroy();
+    }
+    self.global.destroy();
+}

--- a/river/Server.zig
+++ b/river/Server.zig
@@ -35,6 +35,7 @@ const Output = @import("Output.zig");
 const Root = @import("Root.zig");
 const SceneNodeData = @import("SceneNodeData.zig");
 const StatusManager = @import("StatusManager.zig");
+const ForeignToplevelListManager = @import("ForeignToplevelListManager.zig");
 const XdgDecoration = @import("XdgDecoration.zig");
 const XdgToplevel = @import("XdgToplevel.zig");
 const XwaylandOverrideRedirect = @import("XwaylandOverrideRedirect.zig");
@@ -75,6 +76,7 @@ config: Config,
 control: Control,
 status_manager: StatusManager,
 layout_manager: LayoutManager,
+foreign_toplevel_list_manager: ForeignToplevelListManager,
 idle_inhibitor_manager: IdleInhibitorManager,
 lock_manager: LockManager,
 
@@ -134,6 +136,7 @@ pub fn init(self: *Self) !void {
     try self.control.init();
     try self.status_manager.init();
     try self.layout_manager.init();
+    try self.foreign_toplevel_list_manager.init();
     try self.idle_inhibitor_manager.init();
     try self.lock_manager.init();
 

--- a/river/View.zig
+++ b/river/View.zig
@@ -600,6 +600,12 @@ pub fn notifyAppId(view: *Self) void {
 }
 
 pub fn addForeignToplevelListHandle(view: *Self, handle: *ext.ForeignToplevelHandleV1) void {
+    handle.setHandler(
+        *Self,
+        foreignToplevelHandleV1handleRequest,
+        foreignToplevelHandleV1handleDestroy,
+        view,
+    );
     view.foreign_toplevel_list_handles.append(handle);
     if (view.getTitle()) |title| handle.sendTitle(title);
     if (view.getAppId()) |app_id| handle.sendAppId(app_id);
@@ -612,4 +618,21 @@ pub fn addForeignToplevelListHandle(view: *Self, handle: *ext.ForeignToplevelHan
     };
     handle.sendIdentifier(id_str);
     handle.sendDone();
+}
+
+fn foreignToplevelHandleV1handleRequest(
+    handle: *ext.ForeignToplevelHandleV1,
+    request: ext.ForeignToplevelHandleV1.Request,
+    _: *Self,
+) void {
+    switch (request) {
+        .destroy => handle.destroy(),
+    }
+}
+
+fn foreignToplevelHandleV1handleDestroy(
+    handle: *ext.ForeignToplevelHandleV1,
+    _: *Self,
+) void {
+    handle.getLink().remove();
 }

--- a/river/View.zig
+++ b/river/View.zig
@@ -208,7 +208,7 @@ pub fn create(impl: Impl) error{OutOfMemory}!*Self {
         .pending_focus_stack_link = undefined,
         .inflight_wm_stack_link = undefined,
         .inflight_focus_stack_link = undefined,
-        .id = server.wl_server.nextSerial(),
+        .id = server.root.nextViewId(),
     };
 
     view.foreign_toplevel_list_handles.init();

--- a/river/command.zig
+++ b/river/command.zig
@@ -55,6 +55,7 @@ const command_impls = std.ComptimeStringMap(
         .{ "focus-output",              @import("command/output.zig").focusOutput },
         .{ "focus-previous-tags",       @import("command/tags.zig").focusPreviousTags },
         .{ "focus-view",                @import("command/focus_view.zig").focusView },
+        .{ "focus-view-by-id",          @import("command/focus_view.zig").focusViewById },
         .{ "hide-cursor",               @import("command/cursor.zig").cursor },
         .{ "input",                     @import("command/input.zig").input },
         .{ "keyboard-group-add",        @import("command/keyboard_group.zig").keyboardGroupAdd },

--- a/river/command/focus_view.zig
+++ b/river/command/focus_view.zig
@@ -91,7 +91,7 @@ pub fn focusViewById(
     if (seat.focused != .view) return;
     if (seat.focused.view.pending.fullscreen) return;
 
-    const id = fmt.parseInt(u8, args[1], 10) catch return;
+    const id = fmt.parseInt(usize, args[1], 10) catch return;
 
     var it = server.root.views.iterator(.forward);
     while (it.next()) |view| {


### PR DESCRIPTION
Just a (pretty bad) experimental implementation of the new ext-foreign-toplevel-info-v1 protocol. Also adds a `focus-view-by-id` command, so that this little window switcher now works:

```sh
#!/bin/bash 
shopt -s lastpipe 
./lswt -c " ti" | fuzzel -d | cut -d' ' -f2 | read sel 
riverctl focus-view-by-id "${sel}" 
```

There will certainly be a wlroots implemention for this eventually, so this needs no review. However I think giving each view a unique id and the `focus-view-by-id`  command are things we could do before that already.

While we're at it, what other view-id based operations should we support?
* `close-view-by-id` ?
* `set-view-tags-by-id` ? <-- this could be used for example to make the window switcher move the selected view to the current tags

---

**edit:** slightly better window switcher:

```python
#!/bin/env python3

import subprocess

try:
    lswt_command = ["lswt", "-c", "	ita"]
    lswt_output = subprocess.check_output(lswt_command)
    lswt_output = lswt_output.decode("utf8")
    lswt_output = lswt_output.split("\n")
    lswt_output = [s for s in lswt_output if s] # filter out empty lines
    lswt_output = [s.split("\t") for s in lswt_output]
except:
    print("lswt failed")
    exit(1)

id_list = [s[0] for s in lswt_output]
title_list = [s[1] for s in lswt_output]
appid_list = [s[2] for s in lswt_output]

if len(id_list) == 0:
    exit(0)

if id_list[0] == "unsupported":
    print("ext-foreign-toplevel-list-v1 is apparently not supported")
    exit(1)

fuzzel_input = ''.join([ t + " (" + a + ")\n" for t, a in zip(title_list, appid_list)])

try:
    fuzzel_command = ["fuzzel", "-d", "--index"]
    index = subprocess.check_output(fuzzel_command, input=fuzzel_input, encoding="utf8")
    index = int(index)
    selected_window_id = id_list[index]
except:
    print("fuzzel failed or was exited")
    exit(1)

try:
    riverctl_command = ["riverctl", "focus-view-by-id", selected_window_id]
    index = subprocess.run(riverctl_command)
except:
    print("riverctl failed")
    exit(1)

```