### PR TITLE
river: add position, dimension and fullscreen rules

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -1,6 +1,6 @@
 function __riverctl_completion ()
 {
-	local rule_actions="float no-float ssd csd tag output"
+	local rule_actions="float no-float ssd csd tag output position dimensions"
 	if [ "${COMP_CWORD}" -eq 1 ]
 	then
 		OPTS=" \
@@ -66,7 +66,7 @@ function __riverctl_completion ()
 			"move"|"snap") OPTS="up down left right" ;;
 			"resize") OPTS="horizontal vertical" ;;
 			"rule-add"|"rule-del") OPTS="-app-id -title $rule_actions" ;;
-			"list-rules") OPTS="float ssd tag output" ;;
+			"list-rules") OPTS="float ssd tag output position dimensions" ;;
 			"map") OPTS="-release -repeat -layout" ;;
 			"unmap") OPTS="-release" ;;
 			"attach-mode") OPTS="top bottom" ;;

--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -1,6 +1,6 @@
 function __riverctl_completion ()
 {
-	local rule_actions="float no-float ssd csd tag output position dimensions"
+	local rule_actions="float no-float ssd csd tag output position dimensions fullscreen no-fullscreen"
 	if [ "${COMP_CWORD}" -eq 1 ]
 	then
 		OPTS=" \
@@ -66,7 +66,7 @@ function __riverctl_completion ()
 			"move"|"snap") OPTS="up down left right" ;;
 			"resize") OPTS="horizontal vertical" ;;
 			"rule-add"|"rule-del") OPTS="-app-id -title $rule_actions" ;;
-			"list-rules") OPTS="float ssd tag output position dimensions" ;;
+			"list-rules") OPTS="float ssd tag output position dimensions fullscreen" ;;
 			"map") OPTS="-release -repeat -layout" ;;
 			"unmap") OPTS="-release" ;;
 			"attach-mode") OPTS="top bottom" ;;

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -88,10 +88,10 @@ complete -c riverctl -n '__fish_seen_subcommand_from unmap'                     
 complete -c riverctl -n '__fish_seen_subcommand_from attach-mode'                 -n '__fish_riverctl_complete_arg 2' -a 'top bottom'
 complete -c riverctl -n '__fish_seen_subcommand_from focus-follows-cursor'        -n '__fish_riverctl_complete_arg 2' -a 'disabled normal always'
 complete -c riverctl -n '__fish_seen_subcommand_from set-cursor-warp'             -n '__fish_riverctl_complete_arg 2' -a 'disabled on-output-change on-focus-change'
-complete -c riverctl -n '__fish_seen_subcommand_from list-rules'                  -n '__fish_riverctl_complete_arg 2' -a 'float ssd tag output position dimensions'
+complete -c riverctl -n '__fish_seen_subcommand_from list-rules'                  -n '__fish_riverctl_complete_arg 2' -a 'float ssd tag output position dimensions fullscreen'
 
 # Options and subcommands for 'rule-add' and 'rule-del'
-set -l rule_actions float no-float ssd csd tag output position dimensions
+set -l rule_actions float no-float ssd csd tag output position dimensions fullscreen no-fullscreen
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'not __fish_seen_argument -o app-id' -o 'app-id' -r
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'not __fish_seen_argument -o title'  -o 'title' -r
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'test (math (count (commandline -opc)) % 2) -eq 0' -a "$rule_actions"

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -88,10 +88,10 @@ complete -c riverctl -n '__fish_seen_subcommand_from unmap'                     
 complete -c riverctl -n '__fish_seen_subcommand_from attach-mode'                 -n '__fish_riverctl_complete_arg 2' -a 'top bottom'
 complete -c riverctl -n '__fish_seen_subcommand_from focus-follows-cursor'        -n '__fish_riverctl_complete_arg 2' -a 'disabled normal always'
 complete -c riverctl -n '__fish_seen_subcommand_from set-cursor-warp'             -n '__fish_riverctl_complete_arg 2' -a 'disabled on-output-change on-focus-change'
-complete -c riverctl -n '__fish_seen_subcommand_from list-rules'                  -n '__fish_riverctl_complete_arg 2' -a 'float ssd tag output'
+complete -c riverctl -n '__fish_seen_subcommand_from list-rules'                  -n '__fish_riverctl_complete_arg 2' -a 'float ssd tag output position dimensions'
 
 # Options and subcommands for 'rule-add' and 'rule-del'
-set -l rule_actions float no-float ssd csd tag output
+set -l rule_actions float no-float ssd csd tag output position dimensions
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'not __fish_seen_argument -o app-id' -o 'app-id' -r
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'not __fish_seen_argument -o title'  -o 'title' -r
 complete -c riverctl -n '__fish_seen_subcommand_from rule-add rule-del' -n "not __fish_seen_subcommand_from $rule_actions" -n 'test (math (count (commandline -opc)) % 2) -eq 0' -a "$rule_actions"

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -183,9 +183,9 @@ _riverctl()
                     # In case of a new rule added in river, we just need
                     # to add it to the third option between '()',
                     # i.e (float no-float <new-option>)
-                    _arguments '1: :(-app-id -title)' '2: : ' ':: :(float no-float ssd csd tag output position dimensions)'
+                    _arguments '1: :(-app-id -title)' '2: : ' ':: :(float no-float ssd csd tag output position dimensions fullscreen no-fullscreen)'
                 ;;
-                list-rules) _alternative 'arguments:args:(float ssd tag output position dimensions)' ;;
+                list-rules) _alternative 'arguments:args:(float ssd tag output position dimensions fullscreen)' ;;
                 *) return 0 ;;
             esac
         ;;

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -183,9 +183,9 @@ _riverctl()
                     # In case of a new rule added in river, we just need
                     # to add it to the third option between '()',
                     # i.e (float no-float <new-option>)
-                    _arguments '1: :(-app-id -title)' '2: : ' ':: :(float no-float ssd csd tag output)'
+                    _arguments '1: :(-app-id -title)' '2: : ' ':: :(float no-float ssd csd tag output position dimensions)'
                 ;;
-                list-rules) _alternative 'arguments:args:(float ssd tag output)' ;;
+                list-rules) _alternative 'arguments:args:(float ssd tag output position dimensions)' ;;
                 *) return 0 ;;
             esac
         ;;

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -311,7 +311,7 @@ matches everything while _\*\*_ and the empty string are invalid.
 	Both *float* and *no-float* rules are added to the same list,
 	which means that adding a *no-float* rule with the same arguments
 	as a *float* rule will overwrite it. The same holds for *ssd* and
-	*csd* rules.
+	*csd*, *fullscreen* and *no-fullscreen* rules.
 
 	If multiple rules in a list match a given view the most specific
 	rule will be applied. For example with the following rules
@@ -339,7 +339,7 @@ matches everything while _\*\*_ and the empty string are invalid.
 *rule-del* [*-app-id* _glob_|*-title* _glob_] _action_
 	Delete a rule created using *rule-add* with the given arguments.
 
-*list-rules* *float*|*ssd*|*tag*|*position*|*dimensions*
+*list-rules* *float*|*ssd*|*tag*|*position*|*dimensions*|*fullscreen*
 	Print the specified rule list. The output is ordered from most specific
 	to least specific, the same order in which views are checked against
 	when searching for a match. Only the first matching rule in the list

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -274,11 +274,11 @@ For example, _abc_ is matched by _a\*_, _\*a\*_, _\*b\*_, _\*c_, _abc_, and
 _\*_ but not matched by _\*a_, _b\*_, _\*b_, _c\*_, or _ab_. Note that _\*_
 matches everything while _\*\*_ and the empty string are invalid.
 
-*rule-add* [*-app-id* _glob_|*-title* _glob_] _action_ [_argument_]
+*rule-add* [*-app-id* _glob_|*-title* _glob_] _action_ [_arguments_]
 	Add a rule that applies an _action_ to views with *app-id* and *title*
 	matched by the respective _glob_. Omitting *-app-id* or *-title*
 	is equivalent to passing *-app-id* _\*_ or *-title* _\*_.
-	Some actions require an _argument_.
+	Some actions require one or more _arguments_.
 
 	The supported _action_ types are:
 
@@ -298,6 +298,15 @@ matches everything while _\*\*_ and the empty string are invalid.
 	  with make: _HP Inc._, model: _HP 22w_, and serial: _CNC93720WF_, the
 	  identifier would be: _HP Inc. HP 22w CNC93720WF_. If the make, model, or
 	  serial is unknown, the word "Unknown" is used instead.
+	- *position*: Set the initial position of the view, clamping to the
+	  bounds of the output. Requires x and y coordinates of the view as
+	  arguments, both of which must be non-negative. Applies only to new views.
+	- *dimensions*: Set the initial dimensions of the view, clamping to the
+	  constraints of the view. Requires width and height of the view as
+	  arguments, both of which must be non-negative. Applies only to new views.
+	- *fullscreen*: Make the view fullscreen. Applies only to new views.
+	- *no-fullscreen*: Don't make the view fullscreen. Applies only to
+	  new views.
 
 	Both *float* and *no-float* rules are added to the same list,
 	which means that adding a *no-float* rule with the same arguments
@@ -323,10 +332,14 @@ matches everything while _\*\*_ and the empty string are invalid.
 	wishes of the client and may start the view floating based on simple
 	heuristics intended to catch popup-like views.
 
+	If a view is started fullscreen or is not floating, then *position* and
+	*dimensions* rules will have no effect  A view must be matched by a *float*
+	rule in order for them to take effect.
+
 *rule-del* [*-app-id* _glob_|*-title* _glob_] _action_
 	Delete a rule created using *rule-add* with the given arguments.
 
-*list-rules* *float*|*ssd*|*tag*
+*list-rules* *float*|*ssd*|*tag*|*position*|*dimensions*
 	Print the specified rule list. The output is ordered from most specific
 	to least specific, the same order in which views are checked against
 	when searching for a match. Only the first matching rule in the list

--- a/river/Config.zig
+++ b/river/Config.zig
@@ -55,6 +55,16 @@ pub const HideCursorWhenTypingMode = enum {
     enabled,
 };
 
+pub const Position = struct {
+    x: u31,
+    y: u31,
+};
+
+pub const Dimensions = struct {
+    width: u31,
+    height: u31,
+};
+
 /// Color of background in RGBA with premultiplied alpha (alpha should only affect nested sessions)
 background_color: [4]f32 = [_]f32{ 0.0, 0.16862745, 0.21176471, 1.0 }, // Solarized base03
 
@@ -81,6 +91,9 @@ float_rules: RuleList(bool) = .{},
 ssd_rules: RuleList(bool) = .{},
 tag_rules: RuleList(u32) = .{},
 output_rules: RuleList([]const u8) = .{},
+position_rules: RuleList(Position) = .{},
+dimensions_rules: RuleList(Dimensions) = .{},
+fullscreen_rules: RuleList(bool) = .{},
 
 /// The selected focus_follows_cursor mode
 focus_follows_cursor: FocusFollowsCursorMode = .disabled,
@@ -161,6 +174,9 @@ pub fn deinit(self: *Self) void {
         util.gpa.free(rule.value);
     }
     self.output_rules.deinit();
+    self.position_rules.deinit();
+    self.dimensions_rules.deinit();
+    self.fullscreen_rules.deinit();
 
     util.gpa.free(self.default_layout_namespace);
 

--- a/river/View.zig
+++ b/river/View.zig
@@ -488,6 +488,9 @@ pub fn map(view: *Self) !void {
     if (server.config.float_rules.match(view)) |float| {
         view.pending.float = float;
     }
+    if (server.config.fullscreen_rules.match(view)) |fullscreen| {
+        view.pending.fullscreen = fullscreen;
+    }
     if (server.config.ssd_rules.match(view)) |ssd| {
         view.pending.ssd = ssd;
     }

--- a/river/View.zig
+++ b/river/View.zig
@@ -494,9 +494,19 @@ pub fn map(view: *Self) !void {
 
     const focused_output = server.input_manager.defaultSeat().focused_output;
     if (try server.config.outputRuleMatch(view) orelse focused_output) |output| {
-        // Center the initial pending box on the output
-        view.pending.box.x = @divTrunc(@max(0, output.usable_box.width - view.pending.box.width), 2);
-        view.pending.box.y = @divTrunc(@max(0, output.usable_box.height - view.pending.box.height), 2);
+        if (server.config.position_rules.match(view)) |position| {
+            view.pending.box.x = position.x;
+            view.pending.box.y = position.y;
+        } else {
+            // Center the initial pending box on the output
+            view.pending.box.x = @divTrunc(@max(0, output.usable_box.width - view.pending.box.width), 2);
+            view.pending.box.y = @divTrunc(@max(0, output.usable_box.height - view.pending.box.height), 2);
+        }
+
+        if (server.config.dimensions_rules.match(view)) |dimensions| {
+            view.pending.box.width = dimensions.width;
+            view.pending.box.height = dimensions.height;
+        }
 
         view.pending.tags = blk: {
             if (server.config.tag_rules.match(view)) |tags| break :blk tags;


### PR DESCRIPTION
This commit adds position and dimensions rules for configuring
the initial position and dimensions of views.

When a view is not matched by any position rules, it is centered
in the avaliable output space matching the current behavior. If
the provided position rule places the view outside of the output,
the view's position is clamped to the output bounds (with respect
to borders).

When a view is not matched by any dimensions rules, no default
dimensions is set by the server. If the provided dimensions rule
exceeds the minimum or maximum width/height constraints of the view,
the view's width/height is clamped to the constraints.

partially implements https://github.com/riverwm/river/issues/865

I am relatively new to Zig and Wayland, please let me know if I am doing anything incorrectly. I was also going to implement the snap rule proposed in the linked issue but was not sure how it should interact with the position rule.