### PR TITLE
init example: use float-filter-add and csd-filter-add

### DIFF
--- a/example/init
+++ b/example/init
@@ -150,11 +150,11 @@ riverctl border-color-unfocused 0x586e75
 # Set keyboard repeat rate
 riverctl set-repeat 50 300
 
-# Make all views with an app-id that starts with "float" and title "foo" start floating.
-riverctl rule-add float -app-id 'float*' -title 'foo'
+# Make all views with an app-id that starts with "float"
+riverctl float-filter-add app-id 'float*'
 
 # Make all views with app-id "bar" and any title use client-side decorations
-riverctl rule-add csd -app-id "bar"
+riverctl csd-filter-add app-id "bar"
 
 # Set the default layout generator to be rivertile and start it.
 # River will send the process group of the init executable SIGTERM on exit.


### PR DESCRIPTION
The `init` example file is using outdated rivectl commands.

This PR fixes this by using the new commands.