### PR TITLE
completions/zsh: Fix incomplete input names

### DIFF
--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -103,7 +103,7 @@ _riverctl()
                     _arguments '1: :->name' '2: :->commands' ':: :->args'
 
                     case "$state" in
-                        name) _values 'inputs' $(riverctl list-inputs | grep -e '^[^[:space:]]') ;;
+                        name)  _alternative "arguments:args:($(riverctl list-inputs | grep -e '^[^[:space:]]'))" ;;
                         commands)
                             local -a input_subcommands
                             input_subcommands=(


### PR DESCRIPTION
Input name with ':' in it were not suggested entirely.

Sorry I didn't catch this earlier, `_values` wasn't working exactly how I thought. It seems to be fine now.
But if anyone still got any problems I will just remove it and use an empty args like for `glob` in `rule-[add|del]`.