### PR TITLE
restore views to evacuated outputs on reconnect

### DIFF
--- a/river/View.zig
+++ b/river/View.zig
@@ -174,6 +174,9 @@ post_fullscreen_box: wlr.Box = undefined,
 
 foreign_toplevel_handle: ForeignToplevelHandle = .{},
 
+/// Connector name of the output this view occupied before an evacuation.
+output_before_evac: ?[]const u8 = null,
+
 pub fn create(impl: Impl) error{OutOfMemory}!*Self {
     assert(impl != .none);
 
@@ -242,6 +245,8 @@ pub fn destroy(view: *Self) void {
         view.pending_wm_stack_link.remove();
         view.inflight_focus_stack_link.remove();
         view.inflight_wm_stack_link.remove();
+
+        if (view.output_before_evac) |name| util.gpa.free(name);
 
         util.gpa.destroy(view);
     }

--- a/river/command/output.zig
+++ b/river/command/output.zig
@@ -22,6 +22,7 @@ const wlr = @import("wlroots");
 const flags = @import("flags");
 
 const server = &@import("../main.zig").server;
+const util = @import("../util.zig");
 
 const Direction = @import("../command.zig").Direction;
 const PhysicalDirectionDirection = @import("../command.zig").PhysicalDirection;
@@ -78,6 +79,14 @@ pub fn sendToOutput(
         }
 
         seat.focused.view.setPendingOutput(destination_output);
+
+        // When explicitly sending a view to an output, the user likely
+        // does not expect a previously evacuated view moved back to a
+        // re-connecting output.
+        if (seat.focused.view.output_before_evac) |name| {
+            util.gpa.free(name);
+            seat.focused.view.output_before_evac = null;
+        }
 
         server.root.applyPending();
     }


### PR DESCRIPTION
implements #666 

untested, will test tomorrow when I am back at my desk.

(should have waited for #999 to be the next number, but oh well)