### PR TITLE
Keyboard group glob

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -442,7 +442,8 @@ matches everything while _\*\*_ and the empty string are invalid.
 *keyboard-group-add* _group_name_ _input_device_name_
 	Add a keyboard to a keyboard group, identified by the keyboard's
 	input device name. Any currently connected and future keyboards with
-	the given name will be added to the group.
+	the given name will be added to the group. Simple globbing patterns are
+	supported, see the rules section for further information on globs.
 
 *keyboard-group-remove* _group_name_ _input_device_name_
 	Remove a keyboard from a keyboard group, identified by the keyboard's

--- a/river/command/keyboard_group.zig
+++ b/river/command/keyboard_group.zig
@@ -17,6 +17,8 @@
 const std = @import("std");
 const mem = std.mem;
 
+const globber = @import("globber");
+
 const server = &@import("../main.zig").server;
 const util = @import("../util.zig");
 
@@ -69,6 +71,7 @@ pub fn keyboardGroupAdd(
         out.* = msg;
         return;
     };
+    try globber.validate(args[2]);
     try group.addIdentifier(args[2]);
 }
 


### PR DESCRIPTION
Use globber for matching identifiers in keyboard groups.

Real-world use cases:
* A physical keyboard exposes multiple virtual keyboards with similar but not exactly equal names. Using globs simplifies the configuration *a lot* in this case.
* A user wants to have all keyboards in a group, possible with the `*` glob.

Depends on #949 