### PR TITLE
xdg-activation: fix race with transaction system

### DIFF
--- a/river/Server.zig
+++ b/river/Server.zig
@@ -289,7 +289,7 @@ fn handleRequestActivate(
 
     const node_data = SceneNodeData.fromSurface(event.surface) orelse return;
     switch (node_data.data) {
-        .view => |view| if (view.current.focus == 0) {
+        .view => |view| if (view.pending.focus == 0) {
             view.pending.urgent = true;
             server.root.applyPending();
         },


### PR DESCRIPTION
This code could allows the view to be focused and urgent at the same time if the request to activate the view is received just after the pending focus has been set but before the transaction completes.

Hopefully fixes #941, needs testing by someone who can reproduce that issue.