### PR TITLE
Implement cursor_shape_v1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -90,6 +90,7 @@ pub fn build(b: *Build) !void {
     scanner.addSystemProtocol("unstable/pointer-gestures/pointer-gestures-unstable-v1.xml");
     scanner.addSystemProtocol("unstable/pointer-constraints/pointer-constraints-unstable-v1.xml");
     scanner.addSystemProtocol("unstable/xdg-decoration/xdg-decoration-unstable-v1.xml");
+    scanner.addSystemProtocol("staging/cursor-shape/cursor-shape-v1.xml");
 
     scanner.addCustomProtocol("protocol/river-control-unstable-v1.xml");
     scanner.addCustomProtocol("protocol/river-status-unstable-v1.xml");
@@ -114,6 +115,7 @@ pub fn build(b: *Build) !void {
     scanner.generate("zwp_pointer_constraints_v1", 1);
     scanner.generate("zxdg_decoration_manager_v1", 1);
     scanner.generate("ext_session_lock_manager_v1", 1);
+    scanner.generate("wp_cursor_shape_manager_v1", 1);
 
     scanner.generate("zriver_control_v1", 1);
     scanner.generate("zriver_status_manager_v1", 4);

--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -276,12 +276,17 @@ pub fn setTheme(self: *Self, theme: ?[*:0]const u8, _size: ?u32) !void {
     }
 
     if (self.xcursor_name) |name| {
-        self.wlr_cursor.setXcursor(self.xcursor_manager, name);
+        self.setXcursor(name);
     }
 }
 
+pub fn setXcursor(self: *Self, name: [*:0]const u8) void {
+    self.wlr_cursor.setXcursor(self.xcursor_manager, name);
+    self.xcursor_name = name;
+}
+
 fn clearFocus(self: *Self) void {
-    self.wlr_cursor.setXcursor(self.xcursor_manager, "left_ptr");
+    self.setXcursor("left_ptr");
     self.seat.wlr_seat.pointerNotifyClearFocus();
 }
 
@@ -775,7 +780,7 @@ fn enterMode(cursor: *Self, mode: Mode, view: *View, xcursor_name: [*:0]const u8
     }
 
     cursor.seat.wlr_seat.pointerNotifyClearFocus();
-    cursor.wlr_cursor.setXcursor(cursor.xcursor_manager, xcursor_name);
+    cursor.setXcursor(xcursor_name);
 
     server.root.applyPending();
 }

--- a/river/Output.zig
+++ b/river/Output.zig
@@ -306,15 +306,6 @@ pub fn create(wlr_output: *wlr.Output) !void {
     wlr_output.events.frame.add(&output.frame);
     wlr_output.events.present.add(&output.present);
 
-    // Ensure that a cursor image at the output's scale factor is loaded
-    // for each seat.
-    var it = server.input_manager.seats.first;
-    while (it) |seat_node| : (it = seat_node.next) {
-        const seat = &seat_node.data;
-        seat.cursor.xcursor_manager.load(wlr_output.scale) catch
-            log.err("failed to load xcursor theme at scale {}", .{wlr_output.scale});
-    }
-
     output.setTitle();
 
     output.active_link.init();


### PR DESCRIPTION
Also set `xcursor_name` field of the `Cursor`. Currently it is always `null`.

I've put `handleRequestSetCursorShape` in `Server.zig` because that's where the manager is created. I should probably move it to `Cursor.zig`?

Closes #932