### PR TITLE
Focus follows cursor focuses empty outputs

### DIFF
--- a/river/Cursor.zig
+++ b/river/Cursor.zig
@@ -909,6 +909,9 @@ pub fn checkFocusFollowsCursor(self: *Self) void {
             self.seat.focus(view);
             server.root.applyPending();
         }
+    } else {
+        // The output doesn't contain any views, just focus the output.
+        self.updateOutputFocus(self.wlr_cursor.x, self.wlr_cursor.y);
     }
 }
 


### PR DESCRIPTION
Cursor: When `focus-follows-cursor` is set and the cursor moves onto an output where no views are present on the currently visible tags, focus the output itself instead of an individual view.

This is useful e.g. when you want to spawn a terminal on your empty monitor or switch it to a different tag.  Previously such changes would happen to the monitor on which you previous focus was, despite the cursor being somewhere else.