### PR TITLE
Update layout name on empty tags

### DIFF
--- a/river/Root.zig
+++ b/river/Root.zig
@@ -498,10 +498,12 @@ pub fn applyPending(root: *Self) void {
                     }
                 }
 
-                if (layout_count > 0) {
-                    // TODO don't do this if the count has not changed
-                    layout.startLayoutDemand(layout_count);
-                }
+                // This needs to be done if:
+                // - the count has changed
+                // - the layout name has changed due to:
+                //      - the current tag changing
+                //      - the layout changing from a command
+                layout.startLayoutDemand(layout_count);
             }
         }
     }


### PR DESCRIPTION
The layout name reported by the river-status-unstable-v1 protocol (used by waybar) is not being updated when switching to empty tags or when changing the layout of an empty tag. This is because the name is only updated in response to a LayoutDemand - which aren't being generated for empty tags.

I'm not sure what the etiquette of editing TODOs is but I'm not sure there's any simple optimisations left here since there's currently no way to know how root.applyPending() was called. If it was in response to a layout command then the LayoutDemand always needs generating in case it changed the layout name.

I tried thinking of other solutions, but honestly the amount of extra complexity they would need wouldn't be worth it since the potential penalty here only affects empty tags which people won't be on most of the time. If there were more optimisations already in place for handling the case where the count hadn't changed maybe it would be different, but if it was good enough before then it should still be good enough now.