### PR TITLE
Change example init config float and csd rules

### DIFF
--- a/example/init
+++ b/example/init
@@ -151,10 +151,11 @@ riverctl border-color-unfocused 0x586e75
 riverctl set-repeat 50 300
 
 # Make all views with an app-id that starts with "float" and title "foo" start floating.
-riverctl rule-add -app-id 'float*' -title 'foo' float
+riverctl float-filter-add app-id 'float*'
+riverctl float-filter-add title 'foo'
 
 # Make all views with app-id "bar" and any title use client-side decorations
-riverctl rule-add -app-id "bar" csd
+riverctl csd-filter-add app-id "bar"
 
 # Set the default layout generator to be rivertile and start it.
 # River will send the process group of the init executable SIGTERM on exit.


### PR DESCRIPTION
Just a small fix to the init example that I think went unnoticed.