### PR TITLE
command/input: add map-to-output

### DIFF
--- a/completions/bash/riverctl
+++ b/completions/bash/riverctl
@@ -95,7 +95,8 @@ function __riverctl_completion ()
 				tap \
 				tap-button-map \
 				scroll-method \
-				scroll-button"
+				scroll-button \
+				map-to-output"
 			COMPREPLY=($(compgen -W "${OPTS}" -- "${COMP_WORDS[3]}"))
 		elif [ "${COMP_WORDS[1]}" == "hide-cursor" ]
 		then

--- a/completions/fish/riverctl.fish
+++ b/completions/fish/riverctl.fish
@@ -116,6 +116,7 @@ complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_
 complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 3' -a 'tap-button-map'       -d 'Configure the button mapping for tapping'
 complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 3' -a 'scroll-method'        -d 'Set the scroll method'
 complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 3' -a 'scroll-button'        -d 'Set the scroll button'
+complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 3' -a 'map-to-output'        -d 'Map to a given output'
 
 # Subcommands for the subcommands of 'input'
 complete -c riverctl -n '__fish_seen_subcommand_from input; and __fish_riverctl_complete_arg 4; and __fish_seen_subcommand_from drag drag-lock disable-while-typing disable-while-trackpointing middle-emulation natural-scroll left-handed tap' -a 'enabled disabled'

--- a/completions/zsh/_riverctl
+++ b/completions/zsh/_riverctl
@@ -123,6 +123,7 @@ _riverctl()
                                 'tap-button-map:Configure the button mapping for tapping'
                                 'scroll-method:Set the scroll method'
                                 'scroll-button:Set the scroll button'
+                                'map-to-output:Map to a given output'
                             )
 
                         _describe -t command 'command' input_subcommands

--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -527,6 +527,11 @@ However note that not every input device supports every property.
 	Set the scroll button of an input device. _button_ is the name of a Linux
 	input event code.
 
+*input* _name_ *map-to-output* _output_|*disabled*
+	Maps the input to a given output. This is valid even if the output isn't
+	currently active and will lead to the device being mapped once it is
+	connected.
+
 # EXAMPLES
 
 Bind Super+Return in normal mode to spawn a *foot*(1) terminal:

--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -138,6 +138,19 @@ pub fn inputAllowed(self: Self, wlr_surface: *wlr.Surface) bool {
         true;
 }
 
+/// Reconfigures all devices' libinput configuration as well as their output mapping.
+/// This is called on outputs being added or removed and on the input configuration being changed.
+pub fn reconfigureDevices(self: *Self) void {
+    var it = self.devices.iterator(.forward);
+    while (it.next()) |device| {
+        for (self.configs.items) |config| {
+            if (@import("globber").match(device.identifier, config.glob)) {
+                config.apply(device);
+            }
+        }
+    }
+}
+
 fn handleNewInput(listener: *wl.Listener(*wlr.InputDevice), wlr_device: *wlr.InputDevice) void {
     const self = @fieldParentPtr(Self, "new_input", listener);
 

--- a/river/InputManager.zig
+++ b/river/InputManager.zig
@@ -23,6 +23,8 @@ const mem = std.mem;
 const wlr = @import("wlroots");
 const wl = @import("wayland").server.wl;
 
+const globber = @import("globber");
+
 const server = &@import("main.zig").server;
 const util = @import("util.zig");
 
@@ -144,7 +146,7 @@ pub fn reconfigureDevices(self: *Self) void {
     var it = self.devices.iterator(.forward);
     while (it.next()) |device| {
         for (self.configs.items) |config| {
-            if (@import("globber").match(device.identifier, config.glob)) {
+            if (globber.match(device.identifier, config.glob)) {
                 config.apply(device);
             }
         }

--- a/river/Root.zig
+++ b/river/Root.zig
@@ -246,6 +246,8 @@ fn handleNewOutput(_: *wl.Listener(*wlr.Output), wlr_output: *wlr.Output) void {
         }
         wlr_output.destroy();
     };
+
+    server.input_manager.reconfigureDevices();
 }
 
 /// Remove the output from root.active_outputs and the output layout.
@@ -334,6 +336,10 @@ pub fn deactivateOutput(root: *Self, output: *Output) void {
         root.notifyLayoutDemandDone();
     }
     while (output.layouts.first) |node| node.data.destroy();
+
+    // We must call reconfigureDevices here to unmap devices that might be mapped to this output
+    // in order to prevent a segfault in wlroots.
+    server.input_manager.reconfigureDevices();
 }
 
 /// Add the output to root.active_outputs and the output layout if it has not

--- a/river/command/input.zig
+++ b/river/command/input.zig
@@ -112,19 +112,7 @@ pub fn input(
     // add an input configuration at an arbitrary position in the generality
     // ordered list, so the simplest way to ensure the device is configured
     // correctly is to apply all input configurations again, in order.
-    var it = server.input_manager.devices.iterator(.forward);
-    while (it.next()) |device| {
-        // Device does not match the glob given in the command, so its
-        // configuration state after applying all configs again would be
-        // the same.
-        if (!globber.match(device.identifier, args[1])) continue;
-
-        for (server.input_manager.configs.items) |config| {
-            if (globber.match(device.identifier, config.glob)) {
-                config.apply(device);
-            }
-        }
-    }
+    server.input_manager.reconfigureDevices();
 }
 
 fn lessThan(_: void, a: InputConfig, b: InputConfig) bool {


### PR DESCRIPTION
This adds support for a `input X map-to-output Y` command.

closes #635