### PR TITLE
Make the cursor warp when swapping windows

### DIFF
--- a/river/command/view_operations.zig
+++ b/river/command/view_operations.zig
@@ -67,6 +67,7 @@ pub fn swap(
         assert(!target.pending.float);
         assert(!target.pending.fullscreen);
         seat.focused.view.pending_wm_stack_link.swapWith(&target.pending_wm_stack_link);
+        seat.cursor.may_need_warp = true;
         server.root.applyPending();
     }
 }


### PR DESCRIPTION
The cursor should stay on top of the focused window when swapping, just like what was agreed upon in https://codeberg.org/river/river/issues/983.