### PR TITLE
Update riverctl.1.scd

### DIFF
--- a/doc/riverctl.1.scd
+++ b/doc/riverctl.1.scd
@@ -465,8 +465,9 @@ matches everything while _\*\*_ and the empty string are invalid.
 
 The _input_ command can be used to create a configuration rule for an input
 device identified by its _name_.
-The _name_ of an input device consists of its type, its numerical vendor id,
-its numerical product id and finally its self-advertised name, separated by -.
+The _name_ of an input device consists of its type, its decimal vendor id,
+its decimal product id (vendor id and product id are usually written in
+hexadecimal form) and finally its self-advertised name, separated by -.
 Simple globbing patterns are supported, see the rules section for further
 information on globs.
 


### PR DESCRIPTION
Made paragraph explaining the name of input device under input configuration section easier to understand.

The word "numerical" suggests both decimal and hexadecimal so changed "its numerical vendor id, its numerical product it" to "its decimal vendor id, its decimal product id (vendor id and product id are usually written in hexadecimal form)".